### PR TITLE
Parse registerBtcTransaction data to PeginStatus

### DIFF
--- a/src/models/rsk/pegin-status-data.model.ts
+++ b/src/models/rsk/pegin-status-data.model.ts
@@ -5,4 +5,5 @@ export class PeginStatusDataModel {
   rskTxId: string;
   rskRecipient: string;
   createdOn: Date;
+  // TODO: add value field => value: BigInt;
 }

--- a/src/models/rsk/transaction.model.ts
+++ b/src/models/rsk/transaction.model.ts
@@ -6,6 +6,7 @@ export class Transaction {
   blockHeight: number;
   data: Buffer;
   logs: Array<Log>;
+  createdOn: Date;
 
   constructor() {
     this.logs = [];

--- a/src/services/node-bridge-data.provider.ts
+++ b/src/services/node-bridge-data.provider.ts
@@ -41,6 +41,7 @@ export class NodeBridgeDataProvider implements RskBridgeDataProvider {
         let tx = new Transaction();
         tx.blockHeight = lastBlock.number;
         tx.blockHash = lastBlock.hash;
+        tx.createdOn = new Date(lastBlock.timestamp * 1000);
         tx.hash = transaction.hash;
         tx.data = transaction.input;
         let txReceipt = await this.rskNodeService.getTransactionReceipt(tx.hash.toString('hex'));

--- a/src/services/register-btc-transaction-data.parser.ts
+++ b/src/services/register-btc-transaction-data.parser.ts
@@ -1,0 +1,122 @@
+import Web3 from 'web3';
+import {Log} from '../models/rsk/log.model';
+import {PeginStatusDataModel} from '../models/rsk/pegin-status-data.model';
+import {Transaction} from '../models/rsk/transaction.model';
+import {calculateBtcTxHash} from '../utils/btc-utils';
+import {ensure0x} from '../utils/hex-utils';
+
+// TODO: this should be an actual enum
+const PEGIN_STATUSES = {
+  locked: 'LOCKED',
+  rejected: 'REJECTED',
+  notRegistered: 'NOT_REGISTERED'
+}
+
+// TODO: instead of hardcoding the signature we should use precompiled abis library
+const LOCK_BTC_SIGNATURE = '0xec2232bdbe54a92238ce7a6b45d53fb31f919496c6abe1554be1cc8eddb6600a';
+const REJECTED_PEGIN_SIGNATURE = '0x708ce1ead20561c5894a93be3fee64b326b2ad6c198f8253e4bb56f1626053d6';
+
+const BRIDGE_ABI = [{
+  "name": "registerBtcTransaction",
+  "type": "function",
+  "constant": true,
+  "inputs": [
+    {
+      "name": "tx",
+      "type": "bytes"
+    },
+    {
+      "name": "height",
+      "type": "int256"
+    },
+    {
+      "name": "pmt",
+      "type": "bytes"
+    }
+  ],
+  "outputs": []
+}];
+
+class PeginStatus {
+  log: Log;
+  status: string;
+
+  constructor(status: string) {
+    this.status = status;
+  }
+}
+
+export class RegisterBtcTransactionDataParser {
+
+  private getThisLogIfFound(logSignature: string, logs: Array<Log>): Log | null {
+    for (let log of logs) {
+      if (log.topics) {
+        for (let topic of log.topics) {
+          if (topic == logSignature) {
+            return log;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private getbtcTxId(data: Buffer): string {
+    let web3 = new Web3();
+    let registerBtcTransactionAbi = BRIDGE_ABI.find(m => m.name == 'registerBtcTransaction');
+    if (!registerBtcTransactionAbi) {
+      throw new Error('registerBtcTransaction can\'t be found in bridge ABI!');
+    }
+    let decodedParameters = web3.eth.abi.decodeParameters(
+      registerBtcTransactionAbi.inputs,
+      ensure0x(data.toString('hex').substr(10))
+    );
+    // Calculate btc tx id
+    return ensure0x(calculateBtcTxHash(decodedParameters.tx));
+  }
+
+  private getPeginStatus(transaction: Transaction): PeginStatus {
+    let lockBtcLog = this.getLockBtcLogIfExists(transaction.logs);
+    let status: PeginStatus;
+    if (lockBtcLog) {
+      status = new PeginStatus(PEGIN_STATUSES.locked);
+      status.log = lockBtcLog;
+    } else if (this.hasRejectedPeginLog(transaction.logs)) {
+      status = new PeginStatus(PEGIN_STATUSES.rejected);
+    } else {
+      status = new PeginStatus(PEGIN_STATUSES.notRegistered);
+    }
+    return status;
+  }
+
+  getLockBtcLogIfExists(logs: Array<Log>): Log | null {
+    return this.getThisLogIfFound(LOCK_BTC_SIGNATURE, logs);
+  }
+
+  hasRejectedPeginLog(logs: Array<Log>): boolean {
+    return this.getThisLogIfFound(REJECTED_PEGIN_SIGNATURE, logs) != null;
+  }
+
+  parse(transaction: Transaction): PeginStatusDataModel | null {
+    if (!transaction || !transaction.logs || !transaction.logs.length) {
+      // This transaction doesn't have the data required to be parsed
+      return null;
+    }
+    let result = new PeginStatusDataModel();
+    result.rskTxId = transaction.hash.toString('hex');
+    result.rskBlockHeight = transaction.blockHeight;
+    result.createdOn = transaction.createdOn;
+    let peginStatus = this.getPeginStatus(transaction);
+    result.status = peginStatus.status;
+    if (result.status == PEGIN_STATUSES.locked) {
+      // rsk recipient address is always the second topic
+      result.rskRecipient = ensure0x(peginStatus.log.topics[1].substr(27));
+      // TODO: extract the transferred value from the data of the log
+      // result.value = BigInt(0);
+    }
+    result.btcTxId = this.getbtcTxId(transaction.data);
+
+    return result;
+  }
+
+}

--- a/src/utils/btc-utils.ts
+++ b/src/utils/btc-utils.ts
@@ -1,0 +1,12 @@
+import {sha256} from 'js-sha256';
+import {remove0x} from './hex-utils';
+
+export const calculateBtcTxHash = (transaction: string) => {
+  let buffer = Buffer.from(remove0x(transaction), 'hex');
+  let hash = sha256(buffer);
+  buffer = Buffer.from(hash, 'hex');
+  hash = sha256(buffer);
+  let bufferedHash = Buffer.from(hash, 'hex');
+  bufferedHash.reverse();
+  return bufferedHash.toString('hex');
+};

--- a/src/utils/hex-utils.ts
+++ b/src/utils/hex-utils.ts
@@ -1,0 +1,7 @@
+export const ensure0x = (value: string) => {
+  return value.startsWith('0x') ? value : '0x' + value;
+};
+
+export const remove0x = (value: string) => {
+  return !value.startsWith('0x') ? value : value.substring(2);
+}


### PR DESCRIPTION
- Add RegisterBtcTransactionDataParser.
   This parser takes a Transaction and returns a PeginStatus by analyzing the payload and logs of the transaction.
- Add hex-utils to add/remove 0x prefixes
- Add btc-utils to hash a btc transaction
- Integrate data parser to daemon to store real data through the peginStatusDataService