### PR TITLE
Add optional appmode argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,22 @@ docker-compose up -d
 For some reason passing `--env-file` argument to docker-compose doesn't seem to be working fine. That's why we need to copy the `.env` file here too.
 
 ## Run the application
+If you want to start the API alongside the daemon run:
 ```sh
 npm start
 ```
 
+If you prefer to execute just the API run:
+```sh
+npm run start-api
+```
 
-Open http://127.0.0.1:3000 in your browser.
+Open http://127.0.0.1:3000 in your browser to discover the API capabilities
+
+If you prefer to execute just the daemon run:
+```sh
+npm run start-daemon
+```
 
 
 ## Fix code style and formatting issues

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "rebuild": "npm run clean && npm run build",
     "prestart": "npm run rebuild",
     "start": "node -r source-map-support/register .",
+    "start-daemon": "npm run prestart && node -r source-map-support/register . --appmode=DAEMON",
+    "start-api": "npm run prestart && node -r source-map-support/register . --appmode=API",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache"
   },
   "repository": {
@@ -57,7 +59,7 @@
     "@loopback/rest-explorer": "^3.0.5",
     "@loopback/service-proxy": "^3.0.5",
     "@types/mongoose": "^5.11.97",
-    "dotenv": "^8.2.0",
+    "dotenv": "^8.6.0",
     "js-sha256": "^0.9.0",
     "log4js": "^6.3.0",
     "loopback-connector-kv-redis": "^3.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,44 @@
+import {config} from 'dotenv';
 import {configure, getLogger} from 'log4js';
 import {ApplicationConfig, TwpapiApplication} from './application';
 import {DaemonRunner} from './daemon-runner';
 
 export * from './application';
 
-export async function main(options: ApplicationConfig = {}): Promise<TwpapiApplication> {
+enum APP_MODE {
+  API,
+  DAEMON,
+  ALL
+};
+
+const searchAppMode = (): APP_MODE => {
+  let arg = process.argv.find(a => a.startsWith('--appmode='));
+  if (arg) {
+    let value: string = arg.split('=')[1];
+    let parsedEnum = APP_MODE[value as keyof typeof APP_MODE];
+    return parsedEnum !== undefined ? parsedEnum : APP_MODE.ALL;
+  }
+  return APP_MODE.ALL;
+};
+
+export async function main(options: ApplicationConfig = {}): Promise<void> {
   configure('./log-config.json');
 
   let logger = getLogger('app');
+
+  let api: TwpapiApplication;
+  let daemon: DaemonRunner;
 
   let shuttingDown = false;
   async function shutdown() {
     if (!shuttingDown) {
       shuttingDown = true;
-      await app.stop();
-      await daemon.stop();
+      if (api) {
+        await api.stop();
+      }
+      if (daemon) {
+        await daemon.stop();
+      }
       logger.info('Shutting down');
     }
   }
@@ -25,17 +49,21 @@ export async function main(options: ApplicationConfig = {}): Promise<TwpapiAppli
   //catches uncaught exceptions
   process.on('uncaughtException', shutdown.bind(null));
 
-  const app = new TwpapiApplication(options);
-  await app.boot();
-  await app.start();
+  let appMode = searchAppMode();
 
-  const url = app.restServer.url;
-  logger.info(`Server is running at ${url}`);
+  config();
+  if (appMode == APP_MODE.API || appMode == APP_MODE.ALL) {
+    api = new TwpapiApplication(options);
+    await api.boot();
+    await api.start();
 
-  let daemon: DaemonRunner = new DaemonRunner();
-  await daemon.start();
-
-  return app;
+    const url = api.restServer.url;
+    logger.info(`Server is running at ${url}`);
+  }
+  if (appMode == APP_MODE.DAEMON || appMode == APP_MODE.ALL) {
+    daemon = new DaemonRunner();
+    await daemon.start();
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
argument => `--appmode=`
values:
- ALL: default value. starts API and daemon+
- API: only starts API
- DAEMON: only starts daemon

Include new npm scripts to easily start both modes:
- start-api: builds and executes passing api only argument
- start-daemon: builds and executes passing daemon only argument