### PR TITLE
Fix refund address response when is not provided

### DIFF
--- a/src/services/pegin-status/pegin-status.service.ts
+++ b/src/services/pegin-status/pegin-status.service.ts
@@ -215,12 +215,8 @@ export class PeginStatusService {
       }
     }
     if (!foundOpReturn) {
-      if (btcTx.vin[0].isAddress) {
-        returnValue = btcTx.vin[0].addresses[0];
-        this.logger.debug(`Uses sender as refund address: ${returnValue}`);
-      } else {
-        this.logger.warn(`Empty value for refund address`);
-      }
+      returnValue = '';
+      this.logger.warn(`Empty value for refund address`);
     }
     return returnValue;
   }


### PR DESCRIPTION
		I've updated the pegin status service in order to ensure
		the refun address value only when it comes from the OP return
		value.