### PR TITLE
Pegnatories data processor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,6 +14,7 @@ src/services/daemon.service.ts
 src/services/rsk-node.service.ts
 src/dependency-injection-handler.ts
 src/services/pegin-data.processor.ts
+src/services/pegnatories-data.processor.ts
 src/services/generic-data-service.ts
 src/services/mongodb-data.service.ts
 src/services/pegout-data.processor.ts
@@ -23,3 +24,4 @@ src/services/sync-status-mongo.service.ts
 src/services/pegin-status/bitcoin.service.ts
 src/services/pegin-status-data-services/pegin-status-mongo.service.ts
 src/services/pegout-status-data-services/pegout-status-mongo.service.ts
+src/services/pegnatories-status-data-services/pegnatories-status-mongo.service.ts

--- a/src/__tests__/unit/services/daemon.service.unit.ts
+++ b/src/__tests__/unit/services/daemon.service.unit.ts
@@ -49,11 +49,13 @@ describe('Service: DaemonService', () => {
 
     await daemonService.start();
     await daemonService.start();
+    await daemonService.start();
 
     expect(daemonService.started).to.be.true;
 
     sinon.assert.calledOnce(mockedRskSyncChainService.start);
-    sinon.assert.calledTwice(mockedRskBlockProcessorPublisher.addSubscriber);
+    sinon.assert.calledThrice(mockedRskBlockProcessorPublisher.addSubscriber);
+  
 
     await daemonService.stop();
 
@@ -88,7 +90,7 @@ describe('Service: DaemonService', () => {
     await daemonService.start();
 
     clock.tick(1);
-    sinon.assert.calledTwice(mockedRskBlockProcessorPublisher.addSubscriber);
+    sinon.assert.calledThrice(mockedRskBlockProcessorPublisher.addSubscriber);
     expect(mockedRskSyncChainService.sync.called).to.be.true;
 
   });

--- a/src/__tests__/unit/services/daemon.service.unit.ts
+++ b/src/__tests__/unit/services/daemon.service.unit.ts
@@ -9,6 +9,7 @@ import {BridgeService} from '../../../services/bridge.service';
 import {PeginStatusMongoDbDataService} from '../../../services/pegin-status-data-services/pegin-status-mongo.service';
 import {PeginDataProcessor} from '../../../services/pegin-data.processor';
 import {PegoutDataProcessor} from '../../../services/pegout-data.processor';
+import {PegnatoriesDataProcessor} from '../../../services/pegnatories-data.processor';
 import RskBlockProcessorPublisher from '../../../services/rsk-block-processor-publisher';
 import {RskChainSyncService, RskChainSyncSubscriber} from '../../../services/rsk-chain-sync.service';
 import {getRandomHash} from '../../helper';
@@ -40,7 +41,8 @@ describe('Service: DaemonService', () => {
       mockedRskSyncChainService,
       "0",
       new PeginDataProcessor(mockedPeginStatusDataService),
-      new PegoutDataProcessor(mockedPegoutStatusDataService, bridgeService)
+      new PegoutDataProcessor(mockedPegoutStatusDataService, bridgeService),
+      new PegnatoriesDataProcessor()
     );
 
     await daemonService.start();
@@ -72,7 +74,8 @@ describe('Service: DaemonService', () => {
       mockedRskSyncChainService,
       "0",
       new PeginDataProcessor(mockedPeginStatusDataService),
-      new PegoutDataProcessor(mockedPegoutStatusDataService, bridgeService)
+      new PegoutDataProcessor(mockedPegoutStatusDataService, bridgeService),
+      new PegnatoriesDataProcessor()
     );
 
     clock.tick(1);
@@ -96,7 +99,7 @@ describe('Service: DaemonService', () => {
       sinon.createStubInstance(PeginDataProcessor) as SinonStubbedInstance<PeginDataProcessor> & PeginDataProcessor;
     
     const mockedPegoutDataProcessor = sinon.createStubInstance(PegoutDataProcessor) as SinonStubbedInstance<PegoutDataProcessor> & PegoutDataProcessor;
-  
+    const mockedPegnatoriesDataProcessor = sinon.createStubInstance(PegnatoriesDataProcessor) as SinonStubbedInstance<PegnatoriesDataProcessor> & PegnatoriesDataProcessor;
     const deletedBlock = new RskBlock(1, getRandomHash(), getRandomHash());
 
     const daemonService = new DaemonService(
@@ -105,7 +108,8 @@ describe('Service: DaemonService', () => {
       mockedRskSyncChainService,
       "0",
       mockedPeginDataProcessor,
-      mockedPegoutDataProcessor
+      mockedPegoutDataProcessor,
+      mockedPegnatoriesDataProcessor
     );
 
     // Daemon should have subscribed to mockedRskSyncChainService events

--- a/src/__tests__/unit/services/daemon.service.unit.ts
+++ b/src/__tests__/unit/services/daemon.service.unit.ts
@@ -13,6 +13,7 @@ import {PegnatoriesDataProcessor} from '../../../services/pegnatories-data.proce
 import RskBlockProcessorPublisher from '../../../services/rsk-block-processor-publisher';
 import {RskChainSyncService, RskChainSyncSubscriber} from '../../../services/rsk-chain-sync.service';
 import {getRandomHash} from '../../helper';
+import { PegnatoriesStatusDataService } from '../../../services/pegnatories-status-data-services/pegnatories-status-data.service';
 
 describe('Service: DaemonService', () => {
   let clock: sinon.SinonFakeTimers;
@@ -30,6 +31,7 @@ describe('Service: DaemonService', () => {
       sinon.createStubInstance(NodeBridgeDataProvider) as SinonStubbedInstance<RskBlockProcessorPublisher>;
     const mockedPeginStatusDataService = <PeginStatusDataService>{};
     const mockedPegoutStatusDataService = <PegoutStatusDataService>{};
+    const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
     const bridgeService: BridgeService = <BridgeService>{};
     mockedPeginStatusDataService.start = sinon.stub();
     mockedPeginStatusDataService.stop = sinon.stub();
@@ -42,7 +44,7 @@ describe('Service: DaemonService', () => {
       "0",
       new PeginDataProcessor(mockedPeginStatusDataService),
       new PegoutDataProcessor(mockedPegoutStatusDataService, bridgeService),
-      new PegnatoriesDataProcessor()
+      new PegnatoriesDataProcessor(mockedPegnatoriesStatusDataService)
     );
 
     await daemonService.start();
@@ -65,6 +67,7 @@ describe('Service: DaemonService', () => {
     mockedPeginStatusDataService.start = sinon.stub();
     mockedPeginStatusDataService.stop = sinon.stub();
     const mockedPegoutStatusDataService = <PegoutStatusDataService>{};
+    const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
     const bridgeService: BridgeService = <BridgeService>{};
     const mockedRskSyncChainService =
       sinon.createStubInstance(RskChainSyncService) as SinonStubbedInstance<RskChainSyncService> & RskChainSyncService;
@@ -75,7 +78,7 @@ describe('Service: DaemonService', () => {
       "0",
       new PeginDataProcessor(mockedPeginStatusDataService),
       new PegoutDataProcessor(mockedPegoutStatusDataService, bridgeService),
-      new PegnatoriesDataProcessor()
+      new PegnatoriesDataProcessor(mockedPegnatoriesStatusDataService)
     );
 
     clock.tick(1);

--- a/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
@@ -109,7 +109,7 @@ describe('Pegnatories data processor', async () => {
           name: BRIDGE_EVENTS.UPDATE_COLLECTIONS,
           signature:
             '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
-          arguments: {sender: 'JC'},
+          arguments: {sender: 'sender'},
         },
       ],
     };
@@ -128,7 +128,7 @@ describe('Pegnatories data processor', async () => {
 
     await thisService.process(extendedBridgeTx);
 
-    const status: PegnatoriesStatusDataModel = new PegnatoriesStatusDataModel(
+    const data: PegnatoriesStatusDataModel = new PegnatoriesStatusDataModel(
       extendedBridgeTx.txHash,
       extendedBridgeTx.blockNumber,
       extendedBridgeTx.blockHash,
@@ -139,7 +139,7 @@ describe('Pegnatories data processor', async () => {
 
     sinon.assert.calledOnceWithMatch(
       mockedPegnatoriesStatusDataService.set,
-      status,
+      data,
     );
   });
 });

--- a/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
@@ -1,0 +1,86 @@
+import {expect, sinon} from '@loopback/testlab';
+import {PegnatoriesStatusDataService} from '../../../services/pegnatories-status-data-services/pegnatories-status-data.service';
+import {PegnatoriesDataProcessor} from '../../../services/pegnatories-data.processor';
+import {PegnatoriesStatusMongoDbDataService} from '../../../services/pegnatories-status-data-services/pegnatories-status-mongo.service';
+import {SinonStubbedInstance} from 'sinon';
+import {Transaction} from 'bridge-transaction-parser';
+import {BRIDGE_EVENTS} from '../../../utils/bridge-utils';
+import ExtendedBridgeTx from '../../../services/extended-bridge-tx';
+import {bridge} from '@rsksmart/rsk-precompiled-abis';
+import {PegnatoriesStatusDataModel} from '../../../models/rsk/pegnatories-status-data.model';
+import {ExtendedBridgeEvent} from '../../../models/types/bridge-transaction-parser';
+
+const blockHash =
+  '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
+
+describe('Pegnatories data processor', async () => {
+  it('returns filters', () => {
+    const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
+
+    const thisService = new PegnatoriesDataProcessor(
+      mockedPegnatoriesStatusDataService,
+    );
+    expect(thisService.getFilters()).to.be.Array;
+    expect(thisService.getFilters()).to.not.be.empty;
+    expect(thisService.getFilters().length).to.equal(2);
+  });
+
+  it('Persisting data', async () => {
+    const mockedPegnatoriesStatusDataService = sinon.createStubInstance(
+      PegnatoriesStatusMongoDbDataService,
+    ) as SinonStubbedInstance<PegnatoriesStatusDataService>;
+
+    const thisService = new PegnatoriesDataProcessor(
+      mockedPegnatoriesStatusDataService,
+    );
+
+    const createdOn = new Date();
+
+    const bridgeTransaction: Transaction = {
+      txHash:
+        '0x475b7b3203ec6673b5884160736a937c62dc5e6c6c948900d16314bcd0ab25b8',
+      blockNumber: 1,
+      method: {
+        name: '',
+        signature: '',
+        arguments: new Map(),
+      },
+      events: [
+        {
+          name: BRIDGE_EVENTS.UPDATE_COLLECTIONS,
+          signature:
+            '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
+          arguments: {sender: 'JC'},
+        },
+      ],
+    };
+
+    const extendedBridgeTx: ExtendedBridgeTx = {
+      blockHash,
+      txHash: bridgeTransaction.txHash,
+      createdOn,
+      blockNumber: bridgeTransaction.blockNumber,
+      to: bridge.address,
+      method: bridgeTransaction.method,
+      events: bridgeTransaction.events,
+    };
+
+    const events = extendedBridgeTx.events as ExtendedBridgeEvent[];
+
+    await thisService.process(extendedBridgeTx);
+
+    const status: PegnatoriesStatusDataModel = new PegnatoriesStatusDataModel(
+      extendedBridgeTx.txHash,
+      extendedBridgeTx.blockNumber,
+      extendedBridgeTx.blockHash,
+      events[0].arguments.sender,
+      events[0].signature,
+      createdOn,
+    );
+
+    sinon.assert.calledOnceWithMatch(
+      mockedPegnatoriesStatusDataService.set,
+      status,
+    );
+  });
+});

--- a/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
@@ -13,9 +13,6 @@ import {ExtendedBridgeEvent} from '../../../models/types/bridge-transaction-pars
 const blockHash =
   '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
 
-const rskTxHash =
-  '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
-
 describe('Service: PegnatoriesDataProcessor', async () => {
   it('returns filters', () => {
     const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
@@ -79,8 +76,11 @@ describe('Service: PegnatoriesDataProcessor', async () => {
       events[0].arguments.sender,
       events[0].signature,
       createdOn,
-      );
-      
-    sinon.assert.calledOnceWithMatch(mockedPegnatoriesStatusDataService.set, data);
+    );
+
+    sinon.assert.calledOnceWithMatch(
+      mockedPegnatoriesStatusDataService.set,
+      data,
+    );
   });
 });

--- a/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
@@ -13,6 +13,10 @@ import {ExtendedBridgeEvent} from '../../../models/types/bridge-transaction-pars
 const blockHash =
   '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
 
+const rskTxHash =
+  '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
+
+
 describe('Pegnatories data processor', async () => {
   it('returns filters', () => {
     const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
@@ -24,6 +28,61 @@ describe('Pegnatories data processor', async () => {
     expect(thisService.getFilters()).to.not.be.empty;
     expect(thisService.getFilters().length).to.equal(2);
   });
+
+
+  
+  it('event = updateCollections', async() => {
+    const mockedPegnatoriesStatusDataService = sinon.createStubInstance(
+      PegnatoriesStatusMongoDbDataService,
+    ) as SinonStubbedInstance<PegnatoriesStatusDataService>;
+
+    const thisService = new PegnatoriesDataProcessor(
+      mockedPegnatoriesStatusDataService,
+    );
+
+    const rskSenderAddress = '0x3A29282d5144cEa68cb33995Ce82212f4B21ccEc';
+    const btcDestinationAddress = 'mreuQThm58CrYL4WCuY4SmDqiAQzWSy9GR';
+    const amount = 504237;
+
+    const releaseRequestReceivedEventsArgs = {
+      sender : rskSenderAddress,
+      btcDestinationAddress : btcDestinationAddress,
+      amount : amount,
+    };
+
+    const createdOn = new Date();
+
+    const bridgeTransaction: Transaction = {
+      txHash: rskTxHash,
+      blockNumber: 1,
+      method: {
+        name: '',
+        signature: '',
+        arguments: new Map()
+      },
+      events: [{
+        name: BRIDGE_EVENTS.RELEASE_REQUEST_RECEIVED,
+        signature: '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
+        arguments: releaseRequestReceivedEventsArgs
+      }]
+    }
+
+    const extendedBridgeTx: ExtendedBridgeTx = {
+      blockHash,
+      txHash: bridgeTransaction.txHash,
+      createdOn,
+      blockNumber: bridgeTransaction.blockNumber,
+      to: bridge.address,
+      method: bridgeTransaction.method,
+      events: bridgeTransaction.events
+    };
+
+    const events = extendedBridgeTx.events as ExtendedBridgeEvent[];
+
+    expect(thisService.process(extendedBridgeTx)).throwError;
+
+  });
+
 
   it('Persisting data', async () => {
     const mockedPegnatoriesStatusDataService = sinon.createStubInstance(

--- a/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
@@ -16,7 +16,6 @@ const blockHash =
 const rskTxHash =
   '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
 
-
 describe('Pegnatories data processor', async () => {
   it('returns filters', () => {
     const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
@@ -29,62 +28,7 @@ describe('Pegnatories data processor', async () => {
     expect(thisService.getFilters().length).to.equal(2);
   });
 
-
-  
-  it('event = updateCollections', async() => {
-    const mockedPegnatoriesStatusDataService = sinon.createStubInstance(
-      PegnatoriesStatusMongoDbDataService,
-    ) as SinonStubbedInstance<PegnatoriesStatusDataService>;
-
-    const thisService = new PegnatoriesDataProcessor(
-      mockedPegnatoriesStatusDataService,
-    );
-
-    const rskSenderAddress = '0x3A29282d5144cEa68cb33995Ce82212f4B21ccEc';
-    const btcDestinationAddress = 'mreuQThm58CrYL4WCuY4SmDqiAQzWSy9GR';
-    const amount = 504237;
-
-    const releaseRequestReceivedEventsArgs = {
-      sender : rskSenderAddress,
-      btcDestinationAddress : btcDestinationAddress,
-      amount : amount,
-    };
-
-    const createdOn = new Date();
-
-    const bridgeTransaction: Transaction = {
-      txHash: rskTxHash,
-      blockNumber: 1,
-      method: {
-        name: '',
-        signature: '',
-        arguments: new Map()
-      },
-      events: [{
-        name: BRIDGE_EVENTS.RELEASE_REQUEST_RECEIVED,
-        signature: '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
-        arguments: releaseRequestReceivedEventsArgs
-      }]
-    }
-
-    const extendedBridgeTx: ExtendedBridgeTx = {
-      blockHash,
-      txHash: bridgeTransaction.txHash,
-      createdOn,
-      blockNumber: bridgeTransaction.blockNumber,
-      to: bridge.address,
-      method: bridgeTransaction.method,
-      events: bridgeTransaction.events
-    };
-
-    const events = extendedBridgeTx.events as ExtendedBridgeEvent[];
-
-    expect(thisService.process(extendedBridgeTx)).throwError;
-
-  });
-
-
-  it('Persisting data', async () => {
+  it('persisting data', async () => {
     const mockedPegnatoriesStatusDataService = sinon.createStubInstance(
       PegnatoriesStatusMongoDbDataService,
     ) as SinonStubbedInstance<PegnatoriesStatusDataService>;
@@ -137,9 +81,50 @@ describe('Pegnatories data processor', async () => {
       createdOn,
     );
 
-    sinon.assert.calledOnceWithMatch(
-      mockedPegnatoriesStatusDataService.set,
-      data,
+    sinon.assert.calledOnceWithMatch(mockedPegnatoriesStatusDataService.set, data);
+  });
+
+  it('catch error if invalid tx is passed', async () => {
+    const mockedPegnatoriesStatusDataService = sinon.createStubInstance(
+      PegnatoriesStatusMongoDbDataService,
+    ) as SinonStubbedInstance<PegnatoriesStatusDataService>;
+
+    const thisService = new PegnatoriesDataProcessor(
+      mockedPegnatoriesStatusDataService,
     );
+
+    const createdOn = new Date();
+
+    const bridgeTransaction: Transaction = {
+      txHash:
+        '0x475b7b3203ec6673b5884160736a937c62dc5e6c6c948900d16314bcd0ab25b8',
+      blockNumber: 1,
+      method: {
+        name: '',
+        signature: '',
+        arguments: new Map(),
+      },
+      events: [
+        {
+          name: BRIDGE_EVENTS.UPDATE_COLLECTIONS,
+          signature:
+            '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
+          arguments: {sender: 'sender'},
+        },
+      ],
+    };
+
+    const extendedBridgeTx = {
+      blockHash,
+      txHash: bridgeTransaction.txHash,
+      createdOn,
+      blockNumber: bridgeTransaction.blockNumber,
+      to: bridge.address,
+      method: bridgeTransaction.method,
+    };
+
+    await thisService.process(extendedBridgeTx as any);
+
+    expect(mockedPegnatoriesStatusDataService.set(extendedBridgeTx as any)).throwError;
   });
 });

--- a/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegnatories-data.processor.unit.ts
@@ -16,7 +16,7 @@ const blockHash =
 const rskTxHash =
   '0xe934eb559aa52270dcad6ca6a890b19ba8605381b90a72f4a19a850a2e79d660';
 
-describe('Pegnatories data processor', async () => {
+describe('Service: PegnatoriesDataProcessor', async () => {
   it('returns filters', () => {
     const mockedPegnatoriesStatusDataService = <PegnatoriesStatusDataService>{};
 
@@ -25,7 +25,7 @@ describe('Pegnatories data processor', async () => {
     );
     expect(thisService.getFilters()).to.be.Array;
     expect(thisService.getFilters()).to.not.be.empty;
-    expect(thisService.getFilters().length).to.equal(2);
+    expect(thisService.getFilters().length).to.equal(1);
   });
 
   it('persisting data', async () => {
@@ -79,52 +79,8 @@ describe('Pegnatories data processor', async () => {
       events[0].arguments.sender,
       events[0].signature,
       createdOn,
-    );
-
+      );
+      
     sinon.assert.calledOnceWithMatch(mockedPegnatoriesStatusDataService.set, data);
-  });
-
-  it('catch error if invalid tx is passed', async () => {
-    const mockedPegnatoriesStatusDataService = sinon.createStubInstance(
-      PegnatoriesStatusMongoDbDataService,
-    ) as SinonStubbedInstance<PegnatoriesStatusDataService>;
-
-    const thisService = new PegnatoriesDataProcessor(
-      mockedPegnatoriesStatusDataService,
-    );
-
-    const createdOn = new Date();
-
-    const bridgeTransaction: Transaction = {
-      txHash:
-        '0x475b7b3203ec6673b5884160736a937c62dc5e6c6c948900d16314bcd0ab25b8',
-      blockNumber: 1,
-      method: {
-        name: '',
-        signature: '',
-        arguments: new Map(),
-      },
-      events: [
-        {
-          name: BRIDGE_EVENTS.UPDATE_COLLECTIONS,
-          signature:
-            '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
-          arguments: {sender: 'sender'},
-        },
-      ],
-    };
-
-    const extendedBridgeTx = {
-      blockHash,
-      txHash: bridgeTransaction.txHash,
-      createdOn,
-      blockNumber: bridgeTransaction.blockNumber,
-      to: bridge.address,
-      method: bridgeTransaction.method,
-    };
-
-    await thisService.process(extendedBridgeTx as any);
-
-    expect(mockedPegnatoriesStatusDataService.set(extendedBridgeTx as any)).throwError;
   });
 });

--- a/src/dependency-injection-bindings.ts
+++ b/src/dependency-injection-bindings.ts
@@ -26,6 +26,7 @@ export const ServicesBindings = {
   RSK_CHAIN_SYNC_SERVICE: 'services.RskChainSyncService',
   PEGIN_DATA_PROCESSOR: 'services.PeginDataProcessor',
   PEGOUT_DATA_PROCESSOR: 'services.PegoutDataProcessor',
+  PEGNATORIES_DATA_PROCESSOR: 'services.PegnatoriesDataProcessor',
   DAEMON_SERVICE: 'services.DaemonService',
   BRIDGE_SERVICE: 'services.BridgeService',
   ADDRESS_SERVICE: 'services.AddressService',

--- a/src/dependency-injection-bindings.ts
+++ b/src/dependency-injection-bindings.ts
@@ -21,6 +21,7 @@ export const ServicesBindings = {
   RSK_NODE_SERVICE: 'services.RskNodeService',
   PEGIN_STATUS_DATA_SERVICE: 'services.PeginStatusDataService',
   PEGOUT_STATUS_DATA_SERVICE: 'services.PegoutStatusDataService',
+  PEGNATORIES_STATUS_DATA_SERVICE: 'services.PegnatoriesStatusDataService',
   PEGIN_STATUS_SERVICE: 'services.PeginStatusService',
   SYNC_STATUS_DATA_SERVICE: 'services.SyncStatusDataService',
   RSK_CHAIN_SYNC_SERVICE: 'services.RskChainSyncService',

--- a/src/dependency-injection-handler.ts
+++ b/src/dependency-injection-handler.ts
@@ -8,6 +8,7 @@ import {DaemonService} from './services/daemon.service';
 import {NodeBridgeDataProvider} from './services/node-bridge-data.provider';
 import {PeginStatusMongoDbDataService} from './services/pegin-status-data-services/pegin-status-mongo.service';
 import {PegoutStatusMongoDbDataService} from './services/pegout-status-data-services/pegout-status-mongo.service';
+import {PegnatoriesStatusMongoDbDataService} from './services/pegnatories-status-data-services/pegnatories-status-mongo.service'
 import {PeginDataProcessor} from './services/pegin-data.processor';
 import {RskChainSyncService} from './services/rsk-chain-sync.service';
 import {RskNodeService} from './services/rsk-node.service';
@@ -91,6 +92,11 @@ export class DependencyInjectionHandler {
       app
       .bind(ServicesBindings.PEGOUT_STATUS_DATA_SERVICE)
       .toClass(PegoutStatusMongoDbDataService)
+      .inScope(BindingScope.SINGLETON);
+
+      app
+      .bind(ServicesBindings.PEGNATORIES_STATUS_DATA_SERVICE)
+      .toClass(PegnatoriesStatusMongoDbDataService)
       .inScope(BindingScope.SINGLETON);
 
     app

--- a/src/dependency-injection-handler.ts
+++ b/src/dependency-injection-handler.ts
@@ -13,6 +13,7 @@ import {RskChainSyncService} from './services/rsk-chain-sync.service';
 import {RskNodeService} from './services/rsk-node.service';
 import {SyncStatusMongoService} from './services/sync-status-mongo.service';
 import { PegoutDataProcessor } from './services/pegout-data.processor';
+import {PegnatoriesDataProcessor} from './services/pegnatories-data.processor';
 
 export class DependencyInjectionHandler {
   public static configureDependencies(app: Application): void {
@@ -115,6 +116,11 @@ export class DependencyInjectionHandler {
       app
       .bind(ServicesBindings.PEGOUT_DATA_PROCESSOR)
       .toClass(PegoutDataProcessor)
+      .inScope(BindingScope.SINGLETON);
+
+    app
+      .bind(ServicesBindings.PEGNATORIES_DATA_PROCESSOR)
+      .toClass(PegnatoriesDataProcessor)
       .inScope(BindingScope.SINGLETON);
 
     app

--- a/src/dependency-injection-handler.ts
+++ b/src/dependency-injection-handler.ts
@@ -8,7 +8,7 @@ import {DaemonService} from './services/daemon.service';
 import {NodeBridgeDataProvider} from './services/node-bridge-data.provider';
 import {PeginStatusMongoDbDataService} from './services/pegin-status-data-services/pegin-status-mongo.service';
 import {PegoutStatusMongoDbDataService} from './services/pegout-status-data-services/pegout-status-mongo.service';
-import {PegnatoriesStatusMongoDbDataService} from './services/pegnatories-status-data-services/pegnatories-status-mongo.service'
+import {PegnatoriesStatusMongoDbDataService} from './services/pegnatories-status-data-services/pegnatories-status-mongo.service';
 import {PeginDataProcessor} from './services/pegin-data.processor';
 import {RskChainSyncService} from './services/rsk-chain-sync.service';
 import {RskNodeService} from './services/rsk-node.service';
@@ -46,8 +46,8 @@ export class DependencyInjectionHandler {
     app
       .bind(ConstantsBindings.INITIAL_BLOCK)
       .to(new RskBlock(
-        parseInt(process.env.SYNC_INITIAL_BLOCK_HEIGHT || '0'),
-        process.env.SYNC_INITIAL_BLOCK_HASH || '',
+          parseInt(process.env.SYNC_INITIAL_BLOCK_HEIGHT || '0'),
+          process.env.SYNC_INITIAL_BLOCK_HASH || '',
         process.env.SYNC_INITIAL_BLOCK_PREV_HASH || ''
       ));
 
@@ -89,12 +89,12 @@ export class DependencyInjectionHandler {
       .toClass(PeginStatusMongoDbDataService)
       .inScope(BindingScope.SINGLETON);
 
-      app
+    app
       .bind(ServicesBindings.PEGOUT_STATUS_DATA_SERVICE)
       .toClass(PegoutStatusMongoDbDataService)
       .inScope(BindingScope.SINGLETON);
 
-      app
+    app
       .bind(ServicesBindings.PEGNATORIES_STATUS_DATA_SERVICE)
       .toClass(PegnatoriesStatusMongoDbDataService)
       .inScope(BindingScope.SINGLETON);
@@ -119,7 +119,7 @@ export class DependencyInjectionHandler {
       .toClass(PeginDataProcessor)
       .inScope(BindingScope.SINGLETON);
 
-      app
+    app
       .bind(ServicesBindings.PEGOUT_DATA_PROCESSOR)
       .toClass(PegoutDataProcessor)
       .inScope(BindingScope.SINGLETON);
@@ -150,9 +150,9 @@ export class DependencyInjectionHandler {
       .inScope(BindingScope.SINGLETON);
 
     app
-        .bind(ServicesBindings.PEGOUT_STATUS_SERVICE)
-        .toClass(PegoutStatusService)
-        .inScope(BindingScope.SINGLETON);
+      .bind(ServicesBindings.PEGOUT_STATUS_SERVICE)
+      .toClass(PegoutStatusService)
+      .inScope(BindingScope.SINGLETON);
 
   }
 }

--- a/src/models/rsk/pegnatories-status-data.model.ts
+++ b/src/models/rsk/pegnatories-status-data.model.ts
@@ -1,0 +1,17 @@
+import {SearchableModel} from './searchable-model';
+
+export class PegnatoriesStatusDataModel implements SearchableModel {
+  txHash: string;
+  blockNumber: number;
+  blockHash: string;
+  pegnatoryAddress: string;
+  signature: string;
+  createdOn: Date;
+
+  getId() {
+    return this.txHash;
+  }
+  getIdFieldName(): string {
+    return 'txHash';
+  }
+}

--- a/src/models/rsk/pegnatories-status-data.model.ts
+++ b/src/models/rsk/pegnatories-status-data.model.ts
@@ -8,6 +8,22 @@ export class PegnatoriesStatusDataModel implements SearchableModel {
   signature: string;
   createdOn: Date;
 
+  constructor(
+    txHash: string,
+    blockNumber: number,
+    blockHash: string,
+    pegnatoryAddress: string,
+    signature: string,
+    createdOn: Date,
+  ) {
+    this.txHash = txHash;
+    this.blockNumber = blockNumber;
+    this.blockHash = blockHash;
+    this.pegnatoryAddress = pegnatoryAddress;
+    this.signature = signature;
+    this.createdOn = createdOn;
+  }
+
   getId() {
     return this.txHash;
   }

--- a/src/services/daemon.service.ts
+++ b/src/services/daemon.service.ts
@@ -127,6 +127,7 @@ export class DaemonService implements iDaemonService {
       await this.peginStatusStorageService.stop()
       await this.syncService.stop();
       this.rskBlockProcessorPublisher.removeSubscriber(this.peginDataProcessor);
+      this.rskBlockProcessorPublisher.removeSubscriber(this.pegnatoriesDataProcessor);
       this.logger.debug('Stopped');
     }
   }

--- a/src/services/daemon.service.ts
+++ b/src/services/daemon.service.ts
@@ -6,6 +6,7 @@ import {getMetricLogger} from '../utils/metric-logger';
 import {PeginStatusDataService} from './pegin-status-data-services/pegin-status-data.service';
 import {PeginDataProcessor} from './pegin-data.processor';
 import {PegoutDataProcessor} from './pegout-data.processor';
+import {PegnatoriesDataProcessor} from './pegnatories-data.processor';
 import {RskChainSyncService} from './rsk-chain-sync.service';
 import RskBlockProcessorPublisher from './rsk-block-processor-publisher';
 
@@ -14,7 +15,8 @@ export class DaemonService implements iDaemonService {
   syncService: RskChainSyncService;
   peginDataProcessor: PeginDataProcessor;
   pegoutDataProcessor: PegoutDataProcessor;
-  rskBlockProcessorPublisher: RskBlockProcessorPublisher
+  rskBlockProcessorPublisher: RskBlockProcessorPublisher;
+  pegnatoriesDataProcessor: PegnatoriesDataProcessor;
 
   dataFetchInterval: NodeJS.Timer;
   started: boolean;
@@ -35,12 +37,15 @@ export class DaemonService implements iDaemonService {
     @inject(ServicesBindings.PEGIN_DATA_PROCESSOR)
     peginDataProcessor: PeginDataProcessor,
     @inject(ServicesBindings.PEGOUT_DATA_PROCESSOR)
-    pegoutDataProcessor: PegoutDataProcessor
+    pegoutDataProcessor: PegoutDataProcessor,
+    @inject(ServicesBindings.PEGNATORIES_DATA_PROCESSOR)
+    pegnatoriesDataProcessor: PegnatoriesDataProcessor,
   ) {
     this.peginStatusStorageService = peginStatusStorageService;
     this.syncService = syncService;
     this.peginDataProcessor = peginDataProcessor;
     this.pegoutDataProcessor = pegoutDataProcessor;
+    this.pegnatoriesDataProcessor = pegnatoriesDataProcessor;
     this.rskBlockProcessorPublisher = rskBlockProcessorPublisher;
     this.started = false;
     this.logger = getLogger('daemon-service');
@@ -105,6 +110,7 @@ export class DaemonService implements iDaemonService {
 
     this.rskBlockProcessorPublisher.addSubscriber(this.peginDataProcessor);
     this.rskBlockProcessorPublisher.addSubscriber(this.pegoutDataProcessor);
+    this.rskBlockProcessorPublisher.addSubscriber(this.pegnatoriesDataProcessor);
 
     this.logger.debug('Started');
     this.started = true;

--- a/src/services/pegnatories-data.processor.ts
+++ b/src/services/pegnatories-data.processor.ts
@@ -23,8 +23,7 @@ export class PegnatoriesDataProcessor implements FilteredBridgeTransactionProces
 
   getFilters(): BridgeDataFilterModel[] {
     return [
-      new BridgeDataFilterModel(getBridgeSignature(BRIDGE_METHODS.UPDATE_COLLECTIONS)),
-      BridgeDataFilterModel.EMPTY_DATA_FILTER,
+      new BridgeDataFilterModel(getBridgeSignature(BRIDGE_METHODS.UPDATE_COLLECTIONS))
     ];
   }
 

--- a/src/services/pegnatories-data.processor.ts
+++ b/src/services/pegnatories-data.processor.ts
@@ -1,0 +1,39 @@
+import {getLogger, Logger} from 'log4js';
+import {BRIDGE_METHODS, getBridgeSignature} from '../utils/bridge-utils';
+import FilteredBridgeTransactionProcessor from './filtered-bridge-transaction-processor';
+import {BridgeDataFilterModel} from '../models/bridge-data-filter.model';
+import ExtendedBridgeTx from './extended-bridge-tx';
+import {ExtendedBridgeEvent} from "../models/types/bridge-transaction-parser";
+
+const pegnatoriesData = new Map();
+
+export class PegnatoriesDataProcessor implements FilteredBridgeTransactionProcessor {
+  private logger: Logger;
+
+  constructor() {
+    this.logger = getLogger('pegnatoriesDataProcessor');
+  }
+
+  getFilters(): BridgeDataFilterModel[] {
+    return [
+      new BridgeDataFilterModel(getBridgeSignature(BRIDGE_METHODS.UPDATE_COLLECTIONS)),
+      BridgeDataFilterModel.EMPTY_DATA_FILTER,
+    ];
+  }
+
+  async process(extendedBridgeTx: ExtendedBridgeTx): Promise<void> {
+    try {
+      this.logger.debug(`[process] Got tx ${extendedBridgeTx.txHash}`);
+
+      const events = extendedBridgeTx.events as ExtendedBridgeEvent[];
+
+      events.forEach(event => {
+        pegnatoriesData.set(event.arguments.sender, extendedBridgeTx.createdOn);
+        console.log(event)
+      });
+      console.log(pegnatoriesData)
+    } catch (e) {
+      this.logger.error(`[process] error processing: ${e}`);
+    }
+  }
+}

--- a/src/services/pegnatories-data.processor.ts
+++ b/src/services/pegnatories-data.processor.ts
@@ -4,18 +4,16 @@ import {BRIDGE_METHODS, getBridgeSignature} from '../utils/bridge-utils';
 import FilteredBridgeTransactionProcessor from './filtered-bridge-transaction-processor';
 import {BridgeDataFilterModel} from '../models/bridge-data-filter.model';
 import ExtendedBridgeTx from './extended-bridge-tx';
-import {ExtendedBridgeEvent} from "../models/types/bridge-transaction-parser";
+import {ExtendedBridgeEvent} from '../models/types/bridge-transaction-parser';
 import {ServicesBindings} from '../dependency-injection-bindings';
 import {PegnatoriesStatusDataService} from './pegnatories-status-data-services/pegnatories-status-data.service';
-import { PegnatoriesStatusDataModel } from '../models/rsk/pegnatories-status-data.model';
-
-const pegnatoriesData = new Map();
+import {PegnatoriesStatusDataModel} from '../models/rsk/pegnatories-status-data.model';
 
 export class PegnatoriesDataProcessor implements FilteredBridgeTransactionProcessor {
   private logger: Logger;
   private pegnatoriesStatusDataService: PegnatoriesStatusDataService;
 
-  constructor( 
+  constructor(
     @inject(ServicesBindings.PEGNATORIES_STATUS_DATA_SERVICE)
     pegnatoriesStatusDataService: PegnatoriesStatusDataService)
   {
@@ -37,19 +35,18 @@ export class PegnatoriesDataProcessor implements FilteredBridgeTransactionProces
       const events = extendedBridgeTx.events as ExtendedBridgeEvent[];
 
       events.forEach(event => {
-        pegnatoriesData.set(event.arguments.sender, extendedBridgeTx.createdOn);
-        console.log(event)
+        const pegnatoryData = new PegnatoriesStatusDataModel(
+          extendedBridgeTx.txHash,
+          extendedBridgeTx.blockNumber,
+          extendedBridgeTx.blockHash,
+          event.arguments.sender,
+          event.signature,
+          extendedBridgeTx.createdOn
+        );
+        this.pegnatoriesStatusDataService.set(pegnatoryData);
       });
-      console.log(pegnatoriesData)
     } catch (e) {
       this.logger.error(`[process] error processing: ${e}`);
-    }
-    try {
-      // TODO
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.pegnatoriesStatusDataService.set({})
-    } catch(e) {
-      this.logger.warn('[process] There was a problem with the storage', e);
     }
   }
 }

--- a/src/services/pegnatories-data.processor.ts
+++ b/src/services/pegnatories-data.processor.ts
@@ -1,17 +1,26 @@
+import {inject} from '@loopback/core';
 import {getLogger, Logger} from 'log4js';
 import {BRIDGE_METHODS, getBridgeSignature} from '../utils/bridge-utils';
 import FilteredBridgeTransactionProcessor from './filtered-bridge-transaction-processor';
 import {BridgeDataFilterModel} from '../models/bridge-data-filter.model';
 import ExtendedBridgeTx from './extended-bridge-tx';
 import {ExtendedBridgeEvent} from "../models/types/bridge-transaction-parser";
+import {ServicesBindings} from '../dependency-injection-bindings';
+import {PegnatoriesStatusDataService} from './pegnatories-status-data-services/pegnatories-status-data.service';
+import { PegnatoriesStatusDataModel } from '../models/rsk/pegnatories-status-data.model';
 
 const pegnatoriesData = new Map();
 
 export class PegnatoriesDataProcessor implements FilteredBridgeTransactionProcessor {
   private logger: Logger;
+  private pegnatoriesStatusDataService: PegnatoriesStatusDataService;
 
-  constructor() {
+  constructor( 
+    @inject(ServicesBindings.PEGNATORIES_STATUS_DATA_SERVICE)
+    pegnatoriesStatusDataService: PegnatoriesStatusDataService)
+  {
     this.logger = getLogger('pegnatoriesDataProcessor');
+    this.pegnatoriesStatusDataService = pegnatoriesStatusDataService;
   }
 
   getFilters(): BridgeDataFilterModel[] {
@@ -34,6 +43,13 @@ export class PegnatoriesDataProcessor implements FilteredBridgeTransactionProces
       console.log(pegnatoriesData)
     } catch (e) {
       this.logger.error(`[process] error processing: ${e}`);
+    }
+    try {
+      // TODO
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.pegnatoriesStatusDataService.set({})
+    } catch(e) {
+      this.logger.warn('[process] There was a problem with the storage', e);
     }
   }
 }

--- a/src/services/pegnatories-status-data-services/pegnatories-status-data.service.ts
+++ b/src/services/pegnatories-status-data-services/pegnatories-status-data.service.ts
@@ -1,6 +1,4 @@
 import {PegnatoriesStatusDataModel} from '../../models/rsk/pegnatories-status-data.model';
 import {GenericDataService} from '../generic-data-service';
 
-export interface PegnatoriesStatusDataService extends GenericDataService<PegnatoriesStatusDataModel> {
-  //deleteByRskBlockHeight(rskBlockHeight: number): Promise<boolean>;
-}
+export interface PegnatoriesStatusDataService extends GenericDataService<PegnatoriesStatusDataModel> {}

--- a/src/services/pegnatories-status-data-services/pegnatories-status-data.service.ts
+++ b/src/services/pegnatories-status-data-services/pegnatories-status-data.service.ts
@@ -1,0 +1,6 @@
+import {PegnatoriesStatusDataModel} from '../../models/rsk/pegnatories-status-data.model';
+import {GenericDataService} from '../generic-data-service';
+
+export interface PegnatoriesStatusDataService extends GenericDataService<PegnatoriesStatusDataModel> {
+  //deleteByRskBlockHeight(rskBlockHeight: number): Promise<boolean>;
+}

--- a/src/services/pegnatories-status-data-services/pegnatories-status-mongo.service.ts
+++ b/src/services/pegnatories-status-data-services/pegnatories-status-mongo.service.ts
@@ -1,0 +1,44 @@
+import mongoose from 'mongoose';
+import {PegnatoriesStatusDataModel} from '../../models/rsk/pegnatories-status-data.model';
+import {MongoDbDataService} from '../mongodb-data.service';
+import {PegnatoriesStatusDataService} from './pegnatories-status-data.service';
+
+/*
+- THESE MODEL INTERFACES AND CLASSES ARE REQUIRED FOR MONGO BUT WE DON'T WANT THEM EXPOSED OUT OF THIS LAYER
+*/
+interface PegnatoriesStatusMongoModel extends mongoose.Document, PegnatoriesStatusDataModel {
+}
+
+const PegnatoriesStatusSchema = new mongoose.Schema({
+  txHash: {type: String, required: true, unique: true},
+  blockNumber: {type: Number, required: true},
+  blockHash: {type: String, required: true},
+  pegnatoryAddress: {type: String, required: true},
+  signature: {type: String, required: true},
+  createdOn: {type: Date, required: true}
+});
+
+const PegnatoriesStatusConnector = mongoose.model<PegnatoriesStatusMongoModel>("PegnatoriesStatus", PegnatoriesStatusSchema);
+
+export class PegnatoriesStatusMongoDbDataService extends MongoDbDataService<PegnatoriesStatusDataModel, PegnatoriesStatusMongoModel> implements PegnatoriesStatusDataService {
+
+  protected getLoggerName(): string {
+    return 'pegnatoriesStatusMongoService';
+  }
+  protected getConnector(): mongoose.Model<PegnatoriesStatusMongoModel, {}, {}> {
+    return PegnatoriesStatusConnector;
+  }
+  protected getByIdFilter(id: any) {
+    return {txId: id};
+  }
+  protected getManyFilter(filter?: any) {
+    return filter;
+  }
+
+  // public deleteByRskBlockHeight(rskBlockHeight: number): Promise<boolean> {
+  //   return this.getConnector()
+  //     .deleteMany({rskBlockHeight: rskBlockHeight})
+  //     .exec()
+  //     .then(() => true);
+  // }
+}

--- a/src/services/pegnatories-status-data-services/pegnatories-status-mongo.service.ts
+++ b/src/services/pegnatories-status-data-services/pegnatories-status-mongo.service.ts
@@ -34,11 +34,4 @@ export class PegnatoriesStatusMongoDbDataService extends MongoDbDataService<Pegn
   protected getManyFilter(filter?: any) {
     return filter;
   }
-
-  // public deleteByRskBlockHeight(rskBlockHeight: number): Promise<boolean> {
-  //   return this.getConnector()
-  //     .deleteMany({rskBlockHeight: rskBlockHeight})
-  //     .exec()
-  //     .then(() => true);
-  // }
 }


### PR DESCRIPTION
- We create a pegnatories-data.processor.ts to save some pegnatories data from the updateCollection method on a new mongo collection, we also needed to add a new subscriber to the daemon and files related to the mongo database.
- We created a test file for our processor.
- To test our new file, we also needed to modify node-bridge-data.provider.unit.ts and daemon.service.unit.ts.
