### PR TITLE
Bugfix/to search old pegins

### DIFF
--- a/src/__tests__/unit/bridge.handler.unit.ts
+++ b/src/__tests__/unit/bridge.handler.unit.ts
@@ -3,6 +3,8 @@ import {BridgeService} from '../../services';
 import bridgeTransactionParser, {Transaction} from 'bridge-transaction-parser';
 
 const rskTxHash = '0xd2852f38fedf1915978715b8a0dc0670040ac4e9065989c810a5bf29c1e006fb';
+const btcValidTxHash = '7006c53b81e644367bf736e07456af8a1ce487174fc6b5e398f6fa7b8d069daa';
+const btcInvalidTxHash = '1234c53b81e644367bf736e07456af8a1ce487174fc6b5e398f6fa7b8d069daa';
 
 describe('Service: Bridge', () => {
   const bridgeService = new BridgeService();
@@ -21,6 +23,15 @@ describe('Service: Bridge', () => {
     const lockingCap = await bridgeService.getLockingCapAmount();
     expect(lockingCap).to.be.Number();
   });
+
+  it('returns true if tx hash was processed by bridge, false if not', async () => {
+    const txProcessed = await bridgeService.isBtcTxHashAlreadyProcessed(btcValidTxHash);
+    const txNotProcessed = await bridgeService.isBtcTxHashAlreadyProcessed(btcInvalidTxHash);
+
+    expect(txProcessed).to.be.true();
+    expect(txNotProcessed).to.be.false();
+
+  })
 
   it('returns bridge transaction by hash', async () => {
     const bridgeTransaction: Transaction = {

--- a/src/__tests__/unit/services/pegin-status.service.unit.ts
+++ b/src/__tests__/unit/services/pegin-status.service.unit.ts
@@ -48,10 +48,14 @@ const getRskInfo = (btcTxId: string) => {
   return data;
 }
 
+
+// not sure if have to change some errors tests and set
+// isTxProcessed to false (or true)
 const getPeginStatusServiceWithMockedEnvironment = (
   btcTransaction: BitcoinTx | undefined,
   minPeginValue: number,
-  rskTransaction?: PeginStatusDataModel
+  rskTransaction?: PeginStatusDataModel,
+  isTxProcessed?: boolean
 ): PeginStatusService => {
   const mockedBitcoinService =
     sinon.createStubInstance(BitcoinService) as SinonStubbedInstance<BitcoinService> & BitcoinService;
@@ -65,6 +69,7 @@ const getPeginStatusServiceWithMockedEnvironment = (
     sinon.createStubInstance(BridgeService) as SinonStubbedInstance<BridgeService> & BridgeService;
   mockedBridgeService.getMinPeginValue.resolves(minPeginValue);
   mockedBridgeService.getFederationAddress.resolves(federationAddress);
+  mockedBridgeService.isBtcTxHashAlreadyProcessed.resolves(isTxProcessed);
 
   const mockedPeginStatusMongoDbDataService = sinon.createStubInstance(PeginStatusMongoDbDataService);
   mockedPeginStatusMongoDbDataService.getById.resolves(rskTransaction);
@@ -88,7 +93,7 @@ describe('function: getPeginSatusInfo', () => {
     const thisService = getPeginStatusServiceWithMockedEnvironment(undefined, 5);
 
     const result = await thisService.getPeginSatusInfo(btcTxId);
-
+    
     expect(result.btc.txId).to.be.equal(btcTxId);
     expect(result.btc.confirmations).to.be.empty;
     expect(result.rsk).to.be.empty;
@@ -134,7 +139,7 @@ describe('function: getPeginSatusInfo', () => {
       200
     );
 
-    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 500);
+    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 500, undefined, true);
     const result = await thisService.getPeginSatusInfo(btcTxId);
 
     expect(result.btc.txId).to.be.equal(btcTxId);
@@ -155,7 +160,7 @@ describe('function: getPeginSatusInfo', () => {
       200
     );
 
-    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5, getRskInfo(btcTxId));
+    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5, getRskInfo(btcTxId), true);
     const result = await thisService.getPeginSatusInfo(btcTxId);
 
     expect(result.btc.txId).to.be.equal(btcTxId);
@@ -175,8 +180,9 @@ describe('function: getPeginSatusInfo', () => {
       200
     );
 
-    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5);
+    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5, undefined, true);
     const result = await thisService.getPeginSatusInfo(btcTxId);
+
     expect(result.btc.txId).equal(btcTxId);
     expect(result.btc.amountTransferred).to.be.equal(0.01);
     expect(result.btc.federationAddress).to.be.equal(federationAddress);
@@ -185,6 +191,7 @@ describe('function: getPeginSatusInfo', () => {
   })
 
   it('getPeginSatusInfo bech32 without OP_RETURNS return NOT_A_PEGIN error', async () => {
+    // dont know what this test means, so dont know if it needs to be modified
     const btcTxId = 'txId5';
     const randomTransaction: BitcoinTx = getBitcoinTx(
       btcTxId,
@@ -210,7 +217,7 @@ describe('function: getPeginSatusInfo', () => {
       200
     );
 
-    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 200);
+    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 200, undefined, true);
     const result = await thisService.getPeginSatusInfo(btcTxId);
 
     expect(result.btc.txId).equal(btcTxId);
@@ -230,7 +237,7 @@ describe('function: getPeginSatusInfo', () => {
       200
     );
 
-    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5, getRskInfo(btcTxId));
+    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5, getRskInfo(btcTxId), true);
     const result = await thisService.getPeginSatusInfo(btcTxId);
 
     expect(result.btc.txId).equal(btcTxId);
@@ -250,7 +257,7 @@ describe('function: getPeginSatusInfo', () => {
       5
     );
 
-    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5);
+    const thisService = getPeginStatusServiceWithMockedEnvironment(randomTransaction, 5, undefined, true);
     const result = await thisService.getPeginSatusInfo(btcTxId);
 
     expect(result.btc.txId).equal(btcTxId);

--- a/src/services/bridge.service.ts
+++ b/src/services/bridge.service.ts
@@ -95,6 +95,19 @@ export class BridgeService {
     });
   }
 
+  public async isBtcTxHashAlreadyProcessed(txHash: string): Promise<Boolean> {
+    return new Promise<Boolean>((resolve, reject) => {
+      this.bridgeContract.methods
+        .isBtcTxHashAlreadyProcessed(txHash)
+        .call()
+        .then((isProcessed: Boolean) => resolve(isProcessed))
+        .catch((reason: any) => {
+          this.logger.warn(`[isBtcTxHashAlreadyProcessed] Got an error: ${reason}`);
+          reject(reason);
+        });
+    });
+  }
+
   public async getBridgeTransactionByHash(txHash: string): Promise<Transaction> {
     return await bridgeTransactionParser.getBridgeTransactionByTxHash(this.web3, txHash);
   }

--- a/src/services/pegin-status/pegin-status.service.ts
+++ b/src/services/pegin-status/pegin-status.service.ts
@@ -110,10 +110,12 @@ export class PeginStatusService {
           this.logger.debug(errorMessage);
           this.status = Status.ERROR_NOT_A_PEGIN;
         } else {
+
           const federationAddress = await this.bridgeService.getFederationAddress();
-          if (!this.isSentToFederationAddress(federationAddress, btcTx.vout)) {
-            //TODO: Comparing with the last federation. Need to include to comparing federation during the creation of the tx
-            const errorMessage = `Is not a pegin. Tx is not sending to Powpeg Address: ${federationAddress}`;
+          const txIsProcessed = await this.bridgeService.isBtcTxHashAlreadyProcessed(btcTxId);
+          
+          if (!txIsProcessed) {
+            const errorMessage = `Is not a pegin. Tx was not processed in Bitcoin network.`;
             this.logger.debug(errorMessage);
             this.status = Status.ERROR_NOT_A_PEGIN;
           } else {
@@ -155,15 +157,18 @@ export class PeginStatusService {
     return (btcValue / 100000000);
   }
 
-  private isSentToFederationAddress(federationAddress: string, vout: Vout[]): boolean {
-    let found = false;
-    for (let i = 0; vout && i < vout.length && !found; i++) {
-      if (federationAddress === vout[i].addresses[0]) {
-        found = true;
-      }
-    }
-    return found;
-  }
+  
+  // this function is not used any more. maybe should be deleted.
+
+  // private isSentToFederationAddress(federationAddress: string, vout: Vout[]): boolean {
+  //   let found = false;
+  //   for (let i = 0; vout && i < vout.length && !found; i++) {
+  //     if (federationAddress === vout[i].addresses[0]) {
+  //       found = true;
+  //     }
+  //   }
+  //   return found;
+  // }
 
   private getTxSentAmountByAddress(federationAddress: string, txId: string, vout: Vout[]): number {
     let acummulatedAmount = 0;

--- a/src/services/pegin-status/pegin-status.service.ts
+++ b/src/services/pegin-status/pegin-status.service.ts
@@ -14,6 +14,7 @@ import {BtcAddressUtils, calculateBtcTxHashSegWitAndNonSegwit} from '../../utils
 import {ensure0x} from '../../utils/hex-utils';
 import {GenericDataService} from '../generic-data-service';
 import {RskNodeService} from '../rsk-node.service';
+import { isAFedAddress } from '../../utils/federation-addresses';
 
 export class PeginStatusService {
   private logger: Logger;
@@ -111,7 +112,6 @@ export class PeginStatusService {
           this.status = Status.ERROR_NOT_A_PEGIN;
         } else {
 
-          const federationAddress = await this.bridgeService.getFederationAddress();
           const txIsProcessed = await this.bridgeService.isBtcTxHashAlreadyProcessed(btcTxId);
           
           if (!txIsProcessed) {
@@ -119,17 +119,19 @@ export class PeginStatusService {
             this.logger.debug(errorMessage);
             this.status = Status.ERROR_NOT_A_PEGIN;
           } else {
+            const vout = btcTx.vout;
+            const fedDestinationAddress = await this.getTxDestinationFedAddress(vout);
             const time = btcTx.time ?? btcTx.blocktime;
             btcStatus.creationDate = new Date(time * 1000); // We get Timestamp in seconds
             btcStatus.amountTransferred = this.fromSatoshiToBtc(this.getTxSentAmountByAddress(
-              federationAddress,
+              fedDestinationAddress,
               btcTxId,
               btcTx.vout
             ));
             btcStatus.btcWTxId = ensure0x(calculateBtcTxHashSegWitAndNonSegwit(btcTx.hex));            btcStatus.fees = btcTx.fees ? this.fromSatoshiToBtc(btcTx.fees) : 0;
             btcStatus.confirmations = Number(btcTx.confirmations) ?? 0;
             btcStatus.requiredConfirmation = Number(process.env.BTC_CONFIRMATIONS) ?? 100;
-            btcStatus.federationAddress = federationAddress;
+            btcStatus.federationAddress = fedDestinationAddress;
             btcStatus.refundAddress = this.getTxRefundAddress(btcTx);
             this.destinationAddress = this.getxDestinationRskAddress(btcTx);
           }
@@ -157,28 +159,33 @@ export class PeginStatusService {
     return (btcValue / 100000000);
   }
 
-  
-  // this function is not used any more. maybe should be deleted.
+  private getTxDestinationFedAddress = async(vout: Vout[]): Promise<string> => {
+    let fedDestinationAddress = '';
 
-  // private isSentToFederationAddress(federationAddress: string, vout: Vout[]): boolean {
-  //   let found = false;
-  //   for (let i = 0; vout && i < vout.length && !found; i++) {
-  //     if (federationAddress === vout[i].addresses[0]) {
-  //       found = true;
-  //     }
-  //   }
-  //   return found;
-  // }
-
-  private getTxSentAmountByAddress(federationAddress: string, txId: string, vout: Vout[]): number {
-    let acummulatedAmount = 0;
+    // i guess we can modify this to have a "break" after the first if = true,
+    // since the fedDestAddress is just one.
     for (let i = 0; vout && i < vout.length; i++) {
-      if (vout[i].isAddress && federationAddress === vout[i].addresses[0]) {
+      if (vout[i].isAddress && await isAFedAddress(vout[i].addresses[0])) {
+        fedDestinationAddress = vout[i].addresses[0];
+      }
+    }
+    return fedDestinationAddress;
+  }
+
+  private getTxSentAmountByAddress(fedDestinationAddress: string, txId: string, vout: Vout[]): number {
+    let acummulatedAmount = 0;
+
+    // i guess we can modify this to have a "break" after have founding the fedAddress,
+    // since the fedDestAddress is just one. as it say, the accumulatedAmount
+    // will be modified for one time most.
+
+    for (let i = 0; vout && i < vout.length; i++) {
+      if (vout[i].isAddress && fedDestinationAddress === vout[i].addresses[0]) {
         acummulatedAmount += Number(vout[i].value!);
       }
     }
     if (acummulatedAmount === 0) {
-      const errorMessage = `Can not get set amount for address: ${federationAddress} in tx: ${txId}`;
+      const errorMessage = `Can not get set amount for address: ${fedDestinationAddress} in tx: ${txId}`;
       this.logger.error(errorMessage);
     }
     return acummulatedAmount;

--- a/src/utils/federation-addresses.ts
+++ b/src/utils/federation-addresses.ts
@@ -1,0 +1,18 @@
+import { BridgeService } from "../services"
+
+const bridgeService = new BridgeService();
+
+export const allFederationAddresses = async (): Promise<string[]> => {
+  const actualFedAddress = await bridgeService.getFederationAddress();
+  const oldFedAddresses = process.env.FEDERATION_ADDRESSES_HISTORY?.split(" ");
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const allAddresses: string[] = [...oldFedAddresses, actualFedAddress]
+  return allAddresses;
+
+}
+
+export const isAFedAddress =  async (address: string): Promise<boolean> => {
+  const allAddresses = await allFederationAddresses();
+  return allAddresses.includes(address);
+}


### PR DESCRIPTION
The condition to consider a tx a pegin is changed: instead of compare the transaction's destination address to the federation address -that was causing trouble because of the new federation-.
We add a "historical fed addresses" to .env and we are doing the following:
first, we call the "isBtcTxHashAlreadyProcessed" method from the bridge.
if its false, the tx is not a pegin.
if its true, to recover the destination fed Address we iterate through the vout and compare if the selected address "isAFedAddress" (as it say, it is part of the allFedAddresses list, that includes the historical fed addresses and the actual one).


I had to change some tests too because they used the old condition.