### PR TITLE
Handling status errors

### DIFF
--- a/src/__tests__/unit/tx-status.controller.unit.ts
+++ b/src/__tests__/unit/tx-status.controller.unit.ts
@@ -182,5 +182,12 @@ describe('Controller: Tx Status', () => {
          expect(pegoutStatusService.stubs.getPegoutStatusByRskTxHash.calledOnce).to.be.true();
          expect(status.type).to.be.eql(TxStatusType.INVALID_DATA);
       });
+      it('should resolve a txStatus: INVALID_DATA if it is not a valid txId', async () => {
+         const invalidTxId = 'invalid-tx-id'
+         const status = await txStatusController.getTxStatus(invalidTxId);
+         expect(peginStatusService.stubs.getPeginSatusInfo.notCalled).to.be.true();
+         expect(pegoutStatusService.stubs.getPegoutStatusByRskTxHash.notCalled).to.be.true();
+         expect(status.type).to.be.eql(TxStatusType.INVALID_DATA);
+      });
    });
 });

--- a/src/controllers/tx-status.controller.ts
+++ b/src/controllers/tx-status.controller.ts
@@ -7,6 +7,7 @@ import {ServicesBindings} from "../dependency-injection-bindings";
 import {PeginStatusService, PegoutStatusService} from "../services";
 import {PegoutStatus} from "../models/rsk/pegout-status-data-model";
 import { ensure0x, remove0x } from '../utils/hex-utils';
+import { isValidTxId } from '../utils/tx-validator';
 
 export class TxStatusController {
   private logger: Logger;
@@ -33,6 +34,15 @@ export class TxStatusController {
     @param.path.string('txId') txId: string,
   ): Promise<TxStatus> {
     let txStatus:TxStatus;
+    
+    if (!isValidTxId(txId)) {
+      this.logger.warn(`[getTxStatus] the provided tx id: ${txId} is invalid`);
+      txStatus = new TxStatus({
+        type: TxStatusType.INVALID_DATA,
+      });
+      return txStatus;
+    }
+
     try {
       const txHash = remove0x(txId);
       this.logger.debug(`[getTxStatus] trying to get a pegin with txHash: ${txHash}`);

--- a/src/services/pegout-status/pegout-status.service.ts
+++ b/src/services/pegout-status/pegout-status.service.ts
@@ -57,7 +57,7 @@ export class PegoutStatusService {
                             this.logger.error(`[getPegoutStatusByRskTxHash] - not found tx ${e}`);
                             pegoutStatus.status = PegoutStatus.NOT_FOUND;
                         }
-                        this.logger.trace(pegoutStatus.status)
+                        this.logger.trace(pegoutStatus.status);
 
                     } else if (pegoutStatusDbDataModel.status === PegoutStatus.REJECTED) {
                         pegoutStatus = PegoutStatusAppDataModel.fromPegoutStatusDataModelRejected(pegoutStatusDbDataModel);

--- a/src/services/pegout-status/pegout-status.service.ts
+++ b/src/services/pegout-status/pegout-status.service.ts
@@ -40,17 +40,15 @@ export class PegoutStatusService {
                         //TODO Change it when bridgeTransactionParser return PENDING transaction (tx on mempool)
                         try {
                             const rskTransaction: RskTransaction = await this.rskNodeService.getTransaction(rskTxHash, this.ATTACH_TRANSACTION_RECEIPT);
-                            if(rskTransaction) {
-                                const receipt = rskTransaction.receipt;
-                                if(receipt) {
-                                    const transaction: Transaction = await this.rskNodeService.getBridgeTransaction(rskTxHash);
-                                    const extendedModel: ExtendedBridgeTxModel = new ExtendedBridgeTxModel(transaction, rskTransaction);
-                                    pegoutStatus = await this.processTransaction(extendedModel);
-                                } else {
-                                    pegoutStatus.status = PegoutStatus.PENDING;
-                                }
-                            } else {
+                            if (!rskTransaction) {
                                 pegoutStatus.status = PegoutStatus.NOT_FOUND;
+                            }
+                            if(rskTransaction.receipt) {
+                                const transaction: Transaction = await this.rskNodeService.getBridgeTransaction(rskTxHash);
+                                const extendedModel: ExtendedBridgeTxModel = new ExtendedBridgeTxModel(transaction, rskTransaction);
+                                pegoutStatus = await this.processTransaction(extendedModel);
+                            } else {
+                                pegoutStatus.status = PegoutStatus.PENDING;
                             }
                         }
                         catch(e) {

--- a/src/services/rsk-node.service.ts
+++ b/src/services/rsk-node.service.ts
@@ -26,30 +26,28 @@ export class RskNodeService {
     return new Promise<RskTransaction>((resolve, reject) => {
       this.web3.eth.getTransaction(txHash)
         .then((web3Tx) => {
-          if (web3Tx) {
-            rskTx.blockHash = <string> web3Tx.blockHash;
-            rskTx.hash = <string> web3Tx.hash;
-            rskTx.data = <string> web3Tx.input;
-            rskTx.to = <string> web3Tx.to;
-            
-            if(!web3Tx.blockHash || !web3Tx.blockNumber) return resolve(rskTx);
+          if (!web3Tx) return reject(new Error('Tx not found in RSK node.'));
 
-            if(includeReceipt) {
-              this.getTransactionReceipt(rskTx.hash)
-              .then((receipt) => {
-                if(receipt) {
-                  rskTx.receipt = receipt;
-                  return resolve(rskTx);
-                }
-              })
-              .catch((reason) => {
-                return reject(reason);
-              });
-            } else {
-              return resolve(rskTx);
-            }
+          rskTx.blockHash = <string> web3Tx.blockHash;
+          rskTx.hash = <string> web3Tx.hash;
+          rskTx.data = <string> web3Tx.input;
+          rskTx.to = <string> web3Tx.to;
+          
+          if(!web3Tx.blockHash || !web3Tx.blockNumber) return resolve(rskTx);
+
+          if(includeReceipt) {
+            this.getTransactionReceipt(rskTx.hash)
+            .then((receipt) => {
+              if(receipt) {
+                rskTx.receipt = receipt;
+                return resolve(rskTx);
+              }
+            })
+            .catch((reason) => {
+              return reject(reason);
+            });
           } else {
-            return reject(new Error('Tx not found in RSK node.'))
+            return resolve(rskTx);
           }
           })
           .catch((reason) => {

--- a/src/utils/tx-validator.ts
+++ b/src/utils/tx-validator.ts
@@ -1,0 +1,5 @@
+const VALID_TX_ID_REGEX = new RegExp(/^(0x[a-fA-F0-9]{64}|[a-fA-F0-9]{64})$/);
+
+export function isValidTxId(id: string) {
+  return VALID_TX_ID_REGEX.test(id);
+}


### PR DESCRIPTION
- In order to display the correct message on the front-end, modify how errors are handled in the back-end
- Validate input text value before look for a transaction
- If transaction status is PENDING resolve without search for the receipt
