### PR TITLE
Fix/increase unit tests

### DIFF
--- a/src/__tests__/unit/bridge.handler.unit.ts
+++ b/src/__tests__/unit/bridge.handler.unit.ts
@@ -9,17 +9,19 @@ const btcInvalidTxHash = '1234c53b81e644367bf736e07456af8a1ce487174fc6b5e398f6fa
 describe('Service: Bridge', () => {
   const bridgeService = new BridgeService();
 
-  it('should return a valid BTC segwit or legacy federation address ', async () => {
+  it('should return a valid BTC segwit or legacy federation address', async () => {
     const legacyRegex = new RegExp('^[mn][1-9A-HJ-NP-Za-km-z]{26,35}');
     const segwitRegex = new RegExp('^[2][1-9A-HJ-NP-Za-km-z]{26,35}');
     const address = await bridgeService.getFederationAddress();
     expect(legacyRegex.test(address) || segwitRegex.test(address)).to.be.true();
   });
-  it('should return the min value to pegin from bridge', async () => {
+
+  it('should return the min value to pegin from bridge as number', async () => {
     const minValue = await bridgeService.getMinPeginValue();
     expect(minValue).to.be.Number();
   });
-  it('return the Locking Cap from bridge', async () => {
+
+  it('return the Locking Cap from bridge as number', async () => {
     const lockingCap = await bridgeService.getLockingCapAmount();
     expect(lockingCap).to.be.Number();
   });
@@ -31,7 +33,17 @@ describe('Service: Bridge', () => {
     expect(txProcessed).to.be.true();
     expect(txNotProcessed).to.be.false();
 
-  })
+  });
+
+  it('returns rbtc in circulation as number', async() => {
+    const rbtc = await bridgeService.getRbtcInCirculation();
+    expect(rbtc).to.be.Number();
+  });
+
+  it('returns pegin availability as number', async() => {
+    const availability = await bridgeService.getPeginAvailability();
+    expect(availability).to.be.Number();
+  });
 
   it('returns bridge transaction by hash', async () => {
     const bridgeTransaction: Transaction = {
@@ -51,7 +63,7 @@ describe('Service: Bridge', () => {
       ]
     };
     const promise = new Promise<Transaction>((resolve) => resolve(bridgeTransaction));
-    sinon.stub(bridgeTransactionParser,  'getBridgeTransactionByTxHash').returns(promise);
+    sinon.stub(bridgeTransactionParser, 'getBridgeTransactionByTxHash').returns(promise);
     const response = await bridgeService.getBridgeTransactionByHash('0x0001');
     const expectedResponse = await promise;
     expect(response).to.equal(expectedResponse);

--- a/src/__tests__/unit/services/pegout-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegout-data.processor.unit.ts
@@ -896,11 +896,13 @@ describe('Service: PegoutDataProcessor', () => {
     const hasEvent = events.find(event => event.name === BRIDGE_EVENTS.RELEASE_REQUESTED);
     const releaseRequestedEvent = events.find(event => event.name === BRIDGE_EVENTS.RELEASE_REQUESTED);
 
+    mockedPegoutStatusDataService.getLastByOriginatingRskTxHashNewest.resolves(new PegoutStatusDbDataModel());
+    sinon.stub(thisService, 'addValueInSatoshisToBeReceivedAndFee' as any);
+
     expect(hasEvent).true;
     expect(releaseRequestedEvent).not.null;
+    
     await thisService['processIndividualPegout'](extendedBridgeTx);
-
-    // im reaching to line 340 with this test.
-    // im facing trouble to test what it follows, i guess related to the TODO comment on line 334. 
+    sinon.assert.calledTwice(mockedPegoutStatusDataService.set);
   })
 });

--- a/src/__tests__/unit/services/pegout-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegout-data.processor.unit.ts
@@ -851,8 +851,6 @@ describe('Service: PegoutDataProcessor', () => {
     const mockedPegoutStatusDataService = sinon.createStubInstance(PegoutStatusMongoDbDataService) as SinonStubbedInstance<PegoutStatusDataService>;
     const mockedBridgeService = sinon.createStubInstance(BridgeService) as SinonStubbedInstance<BridgeService> & BridgeService;
     const thisService = new PegoutDataProcessor(mockedPegoutStatusDataService, mockedBridgeService);  
-    const getLastByOriginatingRskTxHash = mockedPegoutStatusDataService.getLastByOriginatingRskTxHashNewest as sinon.SinonStub;
-    const mockedPegoutStatus = new PegoutStatusDbDataModel();
 
     const extendedBridgeTx: ExtendedBridgeTx = {
       txHash: "0x6843cfeaafe38e1044ec5638877ff766015b44887d32c7aef7daec84aa3af7c5",
@@ -900,15 +898,6 @@ describe('Service: PegoutDataProcessor', () => {
 
     expect(hasEvent).true;
     expect(releaseRequestedEvent).not.null;
-    
-    // this logic was copied from the processBatchPegouts event's test
-    const eventData = '0xed0b3849b1087653d916f490392b7c7578c4611ef4b0ec1063d6bcd393fb6080';
-    mockedPegoutStatus.isNewestStatus = true;
-    mockedPegoutStatus.btcRecipientAddress = 'mpKPLWXnmqjtXyoqi5yRBYgmF4PswMGj55';
-    mockedPegoutStatus.originatingRskTxHash = eventData;
-    getLastByOriginatingRskTxHash
-      .withArgs(eventData)
-      .resolves(mockedPegoutStatus);
     await thisService['processIndividualPegout'](extendedBridgeTx);
 
     // im reaching to line 340 with this test.

--- a/src/__tests__/unit/services/pegout-status.service.unit.ts
+++ b/src/__tests__/unit/services/pegout-status.service.unit.ts
@@ -10,6 +10,7 @@ import { RskNodeService } from '../../../services/rsk-node.service';
 import { RskTransaction } from '../../../models/rsk/rsk-transaction.model';
 import { ExtendedBridgeTxModel } from '../../../services/extended-bridge-tx';
 import { BridgeEvent, BridgeMethod, Transaction } from 'bridge-transaction-parser';
+import { TransactionReceipt  } from 'web3-eth';
 
 describe('Pegout Status Service:', () => {
     let pegoutStatusService: PegoutStatusService;
@@ -93,29 +94,7 @@ describe('Pegout Status Service:', () => {
         expect(pegoutStatus.status).to.be.deepEqual(PegoutStatus.PENDING);
     });
     it('should return a Pegout Status: != PENDING when existing rskTransaction has receipt', async () => {
-        const mockedLog = [{ 
-            address: '', 
-            data: '', 
-            topics: [''], 
-            logIndex: 0, 
-            transactionIndex: 0, 
-            transactionHash: '', 
-            blockHash: '', 
-            blockNumber: 0
-         }];
-        const mockedTxReceipt = { 
-            status: true, 
-            transactionHash: '', 
-            transactionIndex: 0, 
-            blockHash: '', 
-            blockNumber: 0, 
-            from: '', 
-            to: '', 
-            cumulativeGasUsed: 0, 
-            gasUsed: 0, 
-            logs: mockedLog, 
-            logsBloom: ''
-        };
+        const mockedTxReceipt = {} as TransactionReceipt;
         const rskTransactionWithReceipt: RskTransaction = { 
             hash: 'txHash', 
             blockHash: 'blockHash', 
@@ -125,17 +104,10 @@ describe('Pegout Status Service:', () => {
             to: 'to', 
             receipt: mockedTxReceipt
         };
-        
-        const bridgeMethod: BridgeMethod = { 
-            name: '', 
-            signature: '', 
-            arguments: {} 
-        };
-        const bridgeEvent: BridgeEvent[] = [{ 
-            name: '', 
-            signature: '', 
-            arguments: {} 
-        }];
+
+        const bridgeEvent = [{}] as BridgeEvent[];
+        const bridgeMethod = {} as BridgeMethod;
+
         const transaction: Transaction = { 
             txHash: '', 
             method: bridgeMethod, 

--- a/src/__tests__/unit/services/pegout-status.service.unit.ts
+++ b/src/__tests__/unit/services/pegout-status.service.unit.ts
@@ -7,18 +7,29 @@ import {
     PegoutStatusAppDataModel,
 } from "../../../models/rsk/pegout-status-data-model";
 import { RskNodeService } from '../../../services/rsk-node.service';
+import { RskTransaction } from '../../../models/rsk/rsk-transaction.model';
+import { ExtendedBridgeTxModel } from '../../../services/extended-bridge-tx';
+import { BridgeEvent, BridgeMethod, Transaction } from 'bridge-transaction-parser';
 
 describe('Pegout Status Service:', () => {
     let pegoutStatusService: PegoutStatusService;
+    let pegoutStatusServiceMocked: PegoutStatusService;
     let getLastByOriginatingRskTxHash: sinon.SinonStub;
     let rskNodeService: RskNodeService;
+    let getTransaction: sinon.SinonStub;
+    let getBridgeTransaction: sinon.SinonStub;
+    let processTransaction: sinon.SinonStub;
     let pegoutStatusDataService: StubbedInstanceWithSinonAccessor<PegoutStatusMongoDbDataService>;
     beforeEach(() => {
         pegoutStatusDataService = createStubInstance(PegoutStatusMongoDbDataService);
+        pegoutStatusServiceMocked = createStubInstance(PegoutStatusService);
         rskNodeService = createStubInstance(RskNodeService);
-        getLastByOriginatingRskTxHash = pegoutStatusDataService.getLastByOriginatingRskTxHashNewest as sinon.SinonStub;
-
         pegoutStatusService = new PegoutStatusService(pegoutStatusDataService, rskNodeService);
+        getTransaction = rskNodeService.getTransaction as sinon.SinonStub;
+        getBridgeTransaction = rskNodeService.getBridgeTransaction as sinon.SinonStub;
+        getLastByOriginatingRskTxHash = pegoutStatusDataService.getLastByOriginatingRskTxHashNewest as sinon.SinonStub;
+        //@ts-ignore
+        processTransaction = pegoutStatusServiceMocked.processTransaction as sinon.SinonStub;
     });
     it('should return a valid Pegout Status if there is no record on database', async () => {
         getLastByOriginatingRskTxHash
@@ -59,6 +70,61 @@ describe('Pegout Status Service:', () => {
             btcRawTransaction: 'testBtcRawTx',
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
+    });
+    it('should return a Pegout Status: PENDING', async () => {
+        let rskTransactionWithoutReceipt: RskTransaction = { hash: 'txHash', blockHash: 'blockHash', blockHeight: 300000, data: 'data', createdOn: new Date(), to: 'to', receipt: null };
+        getTransaction
+            .withArgs('RskTestTxId')
+            .resolves(rskTransactionWithoutReceipt);
+        getLastByOriginatingRskTxHash
+            .withArgs('RskTestTxId')
+            .resolves(null);
+        const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
+        expect(pegoutStatus.status).to.be.deepEqual(PegoutStatus.PENDING);
+    });
+    it('should return a Pegout Status: != PENDING', async () => {
+        const log = [{ address: '', data: '', topics: ['',''], logIndex: 0, transactionIndex: 0, transactionHash: '', blockHash: '', blockNumber: 0 },
+                        { address: '', data: '', topics: ['',''], logIndex: 0, transactionIndex: 0, transactionHash: '', blockHash: '', blockNumber: 0 }];
+        const txReceipt = { status: true, transactionHash: '', transactionIndex: 0, blockHash: '', blockNumber: 0, from: '', to: '', cumulativeGasUsed: 0, gasUsed: 0, logs: log, logsBloom: ''};
+        const rskTransactionWithReceipt: RskTransaction = { hash: 'txHash', blockHash: 'blockHash', blockHeight: 300000, data: 'data', createdOn: new Date(), to: 'to', receipt: txReceipt};
+        
+        const bridgeMethod: BridgeMethod = { name: '', signature: '', arguments: {} };
+        const bridgeEvent: BridgeEvent[] = [ { name: '', signature: '', arguments: {} },
+                                            { name: '', signature: '', arguments: {} } ];
+        const transaction: Transaction = { txHash: '', method: bridgeMethod, events: bridgeEvent, blockNumber: 0 }
+        
+        getLastByOriginatingRskTxHash
+            .withArgs('RskTestTxId')
+            .resolves(null);
+        
+        getTransaction
+            .withArgs('RskTestTxId')
+            .resolves(rskTransactionWithReceipt);
+        
+        getBridgeTransaction
+            .withArgs('RskTestTxId')
+            .resolves(transaction)
+        
+        const extendedModel: ExtendedBridgeTxModel = new ExtendedBridgeTxModel(transaction, rskTransactionWithReceipt)
+        
+        const processedTransaction = new PegoutStatusAppDataModel({
+            originatingRskTxHash: 'RskTestTxId',
+            rskTxHash: 'RskTestTxId',
+            rskSenderAddress: 'testSenderAddress',
+            btcRecipientAddress: 'testBtcRecipientAddress',
+            valueRequestedInSatoshis: 500000,
+            valueInSatoshisToBeReceived: 495000,
+            feeInSatoshisToBePaid: 5000,
+            status: PegoutStatus.RECEIVED,
+            btcRawTransaction: 'testBtcRawTx',
+        });
+        
+        processTransaction
+            .withArgs(extendedModel)
+            .resolves(processedTransaction);
+
+        const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
+        expect(pegoutStatus.status).to.not.be.deepEqual(PegoutStatus.PENDING);
     });
     it('should return a Pegout Status: REJECTED', async () => {
         getLastByOriginatingRskTxHash


### PR DESCRIPTION
We went from 77% coverage to 82%.

The increment was focused on important files, as it say:
- went from 68% cov to 96% in pegout status service,
- from 47% cov to almost 74% in bridge service,
- from 60% to 87.5% on pegout data processor.