### PR TITLE
Release request received patch

### DIFF
--- a/src/__tests__/unit/services/pegout-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegout-data.processor.unit.ts
@@ -415,25 +415,25 @@ describe('Service: PegoutDataProcessor', () => {
 
   });
 
-  it('handles RELEASE_REQUESTED status, testnet', async () => {
+  it('handles RELEASE_REQUEST_RECEIVED status, testnet', async () => {
     const mockedPegoutStatusDataService = sinon.createStubInstance(PegoutStatusMongoDbDataService) as SinonStubbedInstance<PegoutStatusDataService>;
     const mockedBridgeService = sinon.createStubInstance(BridgeService) as SinonStubbedInstance<BridgeService> & BridgeService;
     const thisService = new PegoutDataProcessor(mockedPegoutStatusDataService, mockedBridgeService);
-    const rskTxHash = '0x3769e1117683faa318c683af5fb763dc03d431580ecf2ad1271ff25bf946fe9c';
-    const btcTxHash = '0xfbfbc14548d7a352287b5f02199ac909d473333f7c2a072eb4dfda30f97a84e2';
+    const rskTxSender = '0x1234567890123456789012345678901234567890';
+    const btcDestinationAddress = 'mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8';
     const amount = 500000;
     const originatingRskTxHash = '0x5628682b56ef179e066fd12ee25a84436def371b0a11b45cf1d8308ed06f4698';
     const createdOn = new Date();
     const rskBlockHeight = 2831033;
 
-    const releaseRequestedEventsArgs = {
-      rskTxHash : originatingRskTxHash,
-      btcTxHash : btcTxHash,
+    const releaseRequestReceivedEventsArgs = {
+      rskTxSender : rskTxSender,
+      btcDestinationAddress : btcDestinationAddress,
       amount : amount,
     };
 
     const bridgeTransaction: Transaction = {
-      txHash: rskTxHash,
+      txHash: originatingRskTxHash,
       blockNumber: rskBlockHeight,
       method: {
         name: '',
@@ -442,8 +442,8 @@ describe('Service: PegoutDataProcessor', () => {
       },
       events: [{
         name: BRIDGE_EVENTS.RELEASE_REQUEST_RECEIVED,
-        signature: '0x7a7c29481528ac8c2b2e93aee658fddd4dc15304fa723a5c2b88514557bcc790',
-        arguments: releaseRequestedEventsArgs
+        signature: '0x8e04e2f2c246a91202761c435d6a4971bdc7af0617f0c739d900ecd12a6d7266',
+        arguments: releaseRequestReceivedEventsArgs
       }]
     }
 

--- a/src/__tests__/unit/utils/btc-utils.unit.ts
+++ b/src/__tests__/unit/utils/btc-utils.unit.ts
@@ -1,4 +1,5 @@
 import {expect} from '@loopback/testlab';
+import sinon from 'sinon';
 import {BtcAddressUtils, calculateBtcTxHash} from '../../../utils/btc-utils';
 import {
   getLegacyAddressList,
@@ -21,11 +22,27 @@ describe('function: getPeginSatusInfo', () => {
     const result = utility.getBtcAddressFromHash('0x09197f6153cb3a91bb51eec373360a1cb3b7c0e0');
     expect(result).to.be.equal('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8');
   });
+  
+  it('hash160ToBtcAddress invalid - with an invalid hash160', async () => {
+    const utility = new BtcAddressUtils();
+    const result = utility.getBtcAddressFromHash('0x09197f6153cb3a91bb51eec373360a1cb3b7c0e0a');
+    const loggerSpy = sinon.spy(utility.logger, 'warn');
+    expect(result).to.be.equal('09197f6153cb3a91bb51eec373360a1cb3b7c0e0a');
+    expect(loggerSpy.calledWith("Error getBtcAddressFromHash "))
+  });
 
   it('hash160ToBtcAddress valid - with a base58 address', async () => {
     const utility = new BtcAddressUtils();
     const result = utility.getBtcAddressFromHash('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8');
     expect(result).to.be.equal('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8');
+  });
+
+  it('hash160ToBtcAddress invalid - with an invalid base58 address', async () => {
+    const utility = new BtcAddressUtils();
+    const loggerSpy = sinon.spy(utility.logger, 'warn');
+    const result = utility.getBtcAddressFromHash('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8a');
+    expect(result).to.be.equal('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8a');
+    expect(loggerSpy.calledWith("Error getBtcAddressFromHash "))
   });
 
   it('getRefundAddress P2PKH valid', async () => {
@@ -41,7 +58,6 @@ describe('function: getPeginSatusInfo', () => {
   });
 
   it('getRefundAddress P2PKH invalid', async () => {
-
     const utility = new BtcAddressUtils();
     const result = utility.getRefundAddress('01379ad9b7ba73bdc1d4e2e1f6884e3');
     expect(result).to.be.empty();

--- a/src/__tests__/unit/utils/btc-utils.unit.ts
+++ b/src/__tests__/unit/utils/btc-utils.unit.ts
@@ -16,9 +16,15 @@ describe('function: getPeginSatusInfo', () => {
     expect(result).to.be.equal('2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7');
   });
 
-  it('hash160ToBtcAddress valid', async () => {
+  it('hash160ToBtcAddress valid - with a hash160', async () => {
     const utility = new BtcAddressUtils();
     const result = utility.getBtcAddressFromHash('0x09197f6153cb3a91bb51eec373360a1cb3b7c0e0');
+    expect(result).to.be.equal('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8');
+  });
+
+  it('hash160ToBtcAddress valid - with a base58 address', async () => {
+    const utility = new BtcAddressUtils();
+    const result = utility.getBtcAddressFromHash('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8');
     expect(result).to.be.equal('mgM4vPBnDKa8cKkXki4Bp5nQ7hgTGd4va8');
   });
 

--- a/src/utils/btc-utils.ts
+++ b/src/utils/btc-utils.ts
@@ -23,7 +23,7 @@ export const calculateBtcTxHashSegWitAndNonSegwit = (raw: string) => {
 export type AddressType = 'BITCOIN_LEGACY_ADDRESS' | 'BITCOIN_SEGWIT_ADDRESS' | 'BITCOIN_NATIVE_SEGWIT_ADDRESS' | 'BITCOIN_MULTISIGNATURE_ADDRESS';
 
 export class BtcAddressUtils {
-  private logger: Logger;
+  public logger: Logger;
 
   constructor() {
     this.logger = getLogger('BtcAddressUtils');
@@ -57,8 +57,8 @@ export class BtcAddressUtils {
     let hash = remove0x(hash160);
     try{
       // Since Fingerroot the "release_request_received" event changed and now the btcDestinationAddress is a proper Base58 address
-      // Check if the length of the data is different than 40, then it should be an address, otherwise treat it as a hash160
-      if (hash.length != 40) {
+      // Check if the length of the data is equal to 34, then it should be an address, otherwise treat it as a hash160
+      if (hash.length === 34) {
         return hash;
       }
       const OP_DUP = '76';

--- a/src/utils/btc-utils.ts
+++ b/src/utils/btc-utils.ts
@@ -57,8 +57,8 @@ export class BtcAddressUtils {
     let hash = remove0x(hash160);
     try{
       // Since Fingerroot the "release_request_received" event changed and now the btcDestinationAddress is a proper Base58 address
-      // Check if the length of the data is equal to 34, then it should be an address, otherwise treat it as a hash160
-      if (hash.length === 34) {
+      // Check if the length of the data is different than 40, then it should be an address, otherwise treat it as a hash160
+      if (hash.length != 40) {
         return hash;
       }
       const OP_DUP = '76';

--- a/src/utils/btc-utils.ts
+++ b/src/utils/btc-utils.ts
@@ -54,8 +54,13 @@ export class BtcAddressUtils {
   }
 
   public getBtcAddressFromHash(hash160: string): string {
+    let hash = remove0x(hash160);
     try{
-      let hash = remove0x(hash160);
+      // Since Fingerroot the "release_request_received" event changed and now the btcDestinationAddress is a proper Base58 address
+      // Check if the length of the data is different than 40, then it should be an address, otherwise treat it as a hash160
+      if (hash.length != 40) {
+        return hash;
+      }
       const OP_DUP = '76';
       const OP_HASH160 = 'a9';
       const BYTES_TO_PUSH = '14';
@@ -74,7 +79,7 @@ export class BtcAddressUtils {
       return address;
     } catch (e) {
       this.logger.warn("Error getBtcAddressFromHash ", e.message);
-      return hash160;
+      return hash;
     }
   }
 


### PR DESCRIPTION
Add new parsing for the RELEASE_REQUEST_RECEIVED method to properly extract the Bitcoin destination address.

Also fix an existing unit test that was mixing two events: RELEASE_REQUEST and RELEASE_REQUEST_RECEIVED

It is recommended to add more unit tests