### PR TITLE
Add btcTxId in the pegout status

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/prefer-nullish-coalescing": "warn",
     "@typescript-eslint/return-await": "warn",
-    "import/prefer-default-export": "warn",
+    "import/prefer-default-export": "off",
     "no-await-in-loop": "warn",
     "class-methods-use-this": "warn",
     "prefer-destructuring": "warn",
@@ -29,7 +29,7 @@ module.exports = {
     "radix": "off",
     "no-plusplus": "off",
     "spaced-comment": "off",
-    "import/no-cycle": "off"
+    "import/no-cycle": "off",
   },
   "overrides": [
     {

--- a/src/__tests__/unit/services/pegout-data.processor.unit.ts
+++ b/src/__tests__/unit/services/pegout-data.processor.unit.ts
@@ -7,7 +7,7 @@ import ExtendedBridgeTx from '../../../services/extended-bridge-tx';
 import {Transaction} from 'bridge-transaction-parser';
 import { BRIDGE_EVENTS, BRIDGE_METHODS } from '../../../utils/bridge-utils';
 import {bridge} from '@rsksmart/rsk-precompiled-abis';
-import { PegoutStatus, PegoutStatusDbDataModel } from '../../../models/rsk/pegout-status-data-model';
+import { PegoutStatuses, PegoutStatusDbDataModel } from '../../../models/rsk/pegout-status-data-model';
 import { BridgeService } from '../../../services';
 import * as constants from '../../../constants';
 import { BridgeState } from '@rsksmart/bridge-state-data-parser';
@@ -112,7 +112,7 @@ describe('Service: PegoutDataProcessor', () => {
     status.btcRecipientAddress = theBtcDestinationAddress;
     status.valueRequestedInSatoshis = theAmount;
     status.originatingRskBlockHeight = extendedBridgeTx.blockNumber;
-    status.status = PegoutStatus.RECEIVED;
+    status.status = PegoutStatuses.RECEIVED;
     status.rskBlockHash = extendedBridgeTx.blockHash;
     status.originatingRskBlockHash = extendedBridgeTx.blockHash;
     status.isNewestStatus = true;
@@ -177,7 +177,7 @@ describe('Service: PegoutDataProcessor', () => {
     status.btcRecipientAddress = theBtcDestinationAddress;
     status.valueRequestedInSatoshis = theAmount;
     status.originatingRskBlockHeight = extendedBridgeTx.blockNumber;
-    status.status = PegoutStatus.RECEIVED;
+    status.status = PegoutStatuses.RECEIVED;
     status.rskBlockHash = extendedBridgeTx.blockHash;
     status.originatingRskBlockHash = extendedBridgeTx.blockHash;
     status.isNewestStatus = true;
@@ -409,7 +409,7 @@ describe('Service: PegoutDataProcessor', () => {
     status.rskBlockHeight = extendedBridgeTx.blockNumber;
     status.rskSenderAddress = rskSenderAddress;
     status.originatingRskBlockHeight = extendedBridgeTx.blockNumber;
-    status.status = PegoutStatus.REJECTED;
+    status.status = PegoutStatuses.REJECTED;
 
     sinon.assert.calledOnceWithMatch(mockedPegoutStatusDataService.set, status);
 
@@ -533,7 +533,7 @@ describe('Service: PegoutDataProcessor', () => {
     dbPegoutWaitingForConfirmation.originatingRskTxHash = originatingRskTxHash;
     dbPegoutWaitingForConfirmation.rskBlockHeight = pegoutCreationRskBlockHeight;
     dbPegoutWaitingForConfirmation.rskSenderAddress = '0x3A29282d5144cEa68cb33995Ce82212f4B21ccEc';
-    dbPegoutWaitingForConfirmation.status = PegoutStatus.WAITING_FOR_CONFIRMATION;
+    dbPegoutWaitingForConfirmation.status = PegoutStatuses.WAITING_FOR_CONFIRMATION;
     dbPegoutWaitingForConfirmation.btcRawTransaction = btcRawTx1;
     dbPegoutWaitingForConfirmation.originatingRskBlockHeight = originatingRskBlockHeight;
     dbPegoutWaitingForConfirmation.valueRequestedInSatoshis = 521000;
@@ -579,7 +579,7 @@ describe('Service: PegoutDataProcessor', () => {
     pegoutWithWaitingForSignature.originatingRskTxHash = originatingRskTxHash;
     pegoutWithWaitingForSignature.rskBlockHeight = currentRskBlockHeight;
     pegoutWithWaitingForSignature.rskSenderAddress = '0x3A29282d5144cEa68cb33995Ce82212f4B21ccEc';
-    pegoutWithWaitingForSignature.status = PegoutStatus.WAITING_FOR_SIGNATURE;
+    pegoutWithWaitingForSignature.status = PegoutStatuses.WAITING_FOR_SIGNATURE;
     pegoutWithWaitingForSignature.btcRawTransaction = btcRawTx1;
     pegoutWithWaitingForSignature.originatingRskBlockHeight = originatingRskBlockHeight;
     pegoutWithWaitingForSignature.valueRequestedInSatoshis = 521000;
@@ -610,7 +610,7 @@ describe('Service: PegoutDataProcessor', () => {
     dbPegoutWaitingForSignature.originatingRskTxHash = originatingRskTxHash;
     dbPegoutWaitingForSignature.rskBlockHeight = rskBlockHeight - 200;
     dbPegoutWaitingForSignature.rskSenderAddress = '0x3A29282d5144cEa68cb33995Ce82212f4B21ccEc';
-    dbPegoutWaitingForSignature.status = PegoutStatus.WAITING_FOR_SIGNATURE;
+    dbPegoutWaitingForSignature.status = PegoutStatuses.WAITING_FOR_SIGNATURE;
     dbPegoutWaitingForSignature.btcRawTransaction = btcRawTx1;
     dbPegoutWaitingForSignature.originatingRskBlockHeight = 2869983;
     dbPegoutWaitingForSignature.valueRequestedInSatoshis = 521000;
@@ -666,7 +666,7 @@ describe('Service: PegoutDataProcessor', () => {
     pegoutWithSigned.originatingRskTxHash = originatingRskTxHash;
     pegoutWithSigned.rskBlockHeight = rskBlockHeight;
     pegoutWithSigned.rskSenderAddress = '0x3A29282d5144cEa68cb33995Ce82212f4B21ccEc';
-    pegoutWithSigned.status = PegoutStatus.RELEASE_BTC;
+    pegoutWithSigned.status = PegoutStatuses.RELEASE_BTC;
     pegoutWithSigned.btcRawTransaction = btcRawTx1;
     pegoutWithSigned.originatingRskBlockHeight = 2869983;
     pegoutWithSigned.valueRequestedInSatoshis = 521000;
@@ -781,7 +781,7 @@ describe('Service: PegoutDataProcessor', () => {
       rskTxHash: '0x6843cfeaafe38e1044ec5638877ff766015b44887d32c7aef7daec84aa3af7c5_1',
       btcRecipientAddress: 'mpKPLWXnmqjtXyoqi5yRBYgmF4PswMGj55',
       originatingRskTxHash: '0xed0b3849b1087653d916f490392b7c7578c4611ef4b0ec1063d6bcd393fb6080',
-      status: PegoutStatus.WAITING_FOR_CONFIRMATION,
+      status: PegoutStatuses.WAITING_FOR_CONFIRMATION,
       rskBlockHeight: 3552254,
       btcTxHash: btcTxHash,
       isNewestStatus: true,

--- a/src/__tests__/unit/services/pegout-status.service.unit.ts
+++ b/src/__tests__/unit/services/pegout-status.service.unit.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import {PegoutStatusService} from "../../../services";
 import {PegoutStatusMongoDbDataService} from "../../../services/pegout-status-data-services/pegout-status-mongo.service";
 import {
-    PegoutStatus,
+    PegoutStatuses,
     PegoutStatusAppDataModel,
 } from "../../../models/rsk/pegout-status-data-model";
 import { RskNodeService } from '../../../services/rsk-node.service';
@@ -11,6 +11,7 @@ import { RskTransaction } from '../../../models/rsk/rsk-transaction.model';
 import { ExtendedBridgeTxModel } from '../../../services/extended-bridge-tx';
 import { BridgeEvent, BridgeMethod, Transaction } from 'bridge-transaction-parser';
 import { TransactionReceipt  } from 'web3-eth';
+import { PegoutStatus } from '../../../models';
 
 describe('Pegout Status Service:', () => {
     let pegoutStatusService: PegoutStatusService;
@@ -21,6 +22,10 @@ describe('Pegout Status Service:', () => {
     let getBridgeTransaction: sinon.SinonStub;
     let processTransaction: sinon.SinonStub;
     let pegoutStatusDataService: StubbedInstanceWithSinonAccessor<PegoutStatusMongoDbDataService>;
+
+    const testBtcRawTx = "0200000001b2f339ac3c3726afaf42e92e0fe5af60b99241c8f3fcbe214d7e1198dd3a1f3301000000fd250100000000004d1d016453210208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce210225e892391625854128c5c4ea4340de0c2a70570f33db53426fc9c746597a03f421025a2f522aea776fab5241ad72f7f05918e8606676461cb6ce38265a52d4ca9ed62102afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da210344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09556702cd50b27552210216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3210275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f1421034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f5368aeffffffff0214db0600000000001976a91460890b78920fed16f7505dc1e8b66ea249da062288ac4b6d70000000000017a9148f38b3d8ec8816f7f58a390f306bb90bb178d6ac8700000000";
+
+
     beforeEach(() => {
         pegoutStatusDataService = createStubInstance(PegoutStatusMongoDbDataService);
         pegoutStatusServiceMocked = createStubInstance(PegoutStatusService);
@@ -32,13 +37,15 @@ describe('Pegout Status Service:', () => {
         //@ts-ignore
         processTransaction = pegoutStatusServiceMocked.processTransaction as sinon.SinonStub;
     });
+    afterEach(sinon.restore);
+
     it('should return a valid Pegout Status if there is no record on database', async () => {
         getLastByOriginatingRskTxHash
             .withArgs('RskTestTxId')
             .resolves(null);
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
-        const expectedResponse = new PegoutStatusAppDataModel({
-            status: PegoutStatus.NOT_FOUND,
+        const expectedResponse = new PegoutStatus({
+            status: PegoutStatuses.NOT_FOUND,
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
     });
@@ -52,14 +59,14 @@ describe('Pegout Status Service:', () => {
                 valueRequestedInSatoshis: 500000,
                 valueInSatoshisToBeReceived: 495000,
                 feeInSatoshisToBePaid: 5000,
-                status: PegoutStatus.RECEIVED,
-                btcRawTransaction: 'testBtcRawTx',
+                status: PegoutStatuses.RECEIVED,
+                btcRawTransaction: testBtcRawTx,
                 originatingRskTxHash: 'RskTestTxId',
                 rskBlockHeight: 3158962,
                 lastUpdatedOn: Date.now(),
             });
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
-        const expectedResponse = new PegoutStatusAppDataModel({
+        const expectedResponse = new PegoutStatus({
             originatingRskTxHash: 'RskTestTxId',
             rskTxHash: 'RskTestTxId',
             rskSenderAddress: 'testSenderAddress',
@@ -67,8 +74,8 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.RECEIVED,
-            btcRawTransaction: 'testBtcRawTx',
+            status: PegoutStatuses.RECEIVED,
+            btcTxId: '86264805cc07e98eb7744f1584ac1aa0d584e2d2830f7d3da353a118c6ae8544',
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
     });
@@ -91,7 +98,7 @@ describe('Pegout Status Service:', () => {
             .resolves(rskTransactionWithoutReceipt);
         
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('txHash');
-        expect(pegoutStatus.status).to.be.deepEqual(PegoutStatus.PENDING);
+        expect(pegoutStatus.status).to.be.deepEqual(PegoutStatuses.PENDING);
     });
     it('should return a Pegout Status: != PENDING when existing rskTransaction has receipt', async () => {
         const mockedTxReceipt = {} as TransactionReceipt;
@@ -137,7 +144,7 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.RECEIVED,
+            status: PegoutStatuses.RECEIVED,
             btcRawTransaction: 'btcRawTx',
         });
         
@@ -146,7 +153,7 @@ describe('Pegout Status Service:', () => {
             .resolves(processedTransaction);
 
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('rskTxHash');
-        expect(pegoutStatus.status).to.not.be.deepEqual(PegoutStatus.PENDING);
+        expect(pegoutStatus.status).to.not.be.deepEqual(PegoutStatuses.PENDING);
     });
     it('should return a Pegout Status: REJECTED', async () => {
         getLastByOriginatingRskTxHash
@@ -158,18 +165,18 @@ describe('Pegout Status Service:', () => {
                 valueRequestedInSatoshis: 0,
                 valueInSatoshisToBeReceived: 0,
                 feeInSatoshisToBePaid: 0,
-                status: PegoutStatus.REJECTED,
+                status: PegoutStatuses.REJECTED,
                 btcRawTransaction: 'testBtcRawTx',
                 originatingRskTxHash: 'RskTestTxId',
                 rskBlockHeight: 3158962,
                 lastUpdatedOn: Date.now(),
             });
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
-        const expectedResponse = new PegoutStatusAppDataModel({
+        const expectedResponse = new PegoutStatus({
             rskTxHash: 'RskTestTxId',
             rskSenderAddress: 'testSenderAddress',
             valueRequestedInSatoshis: 0,
-            status: PegoutStatus.REJECTED,
+            status: PegoutStatuses.REJECTED,
             originatingRskTxHash: 'RskTestTxId',
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
@@ -184,14 +191,14 @@ describe('Pegout Status Service:', () => {
                 valueRequestedInSatoshis: 500000,
                 valueInSatoshisToBeReceived: 495000,
                 feeInSatoshisToBePaid: 5000,
-                status: PegoutStatus.WAITING_FOR_CONFIRMATION,
-                btcRawTransaction: 'testBtcRawTx',
+                status: PegoutStatuses.WAITING_FOR_CONFIRMATION,
+                btcRawTransaction: testBtcRawTx,
                 originatingRskTxHash: 'RskTestTxId',
                 rskBlockHeight: 3158962,
                 lastUpdatedOn: Date.now(),
             });
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
-        const expectedResponse = new PegoutStatusAppDataModel({
+        const expectedResponse = new PegoutStatus({
             originatingRskTxHash: 'RskTestTxId',
             rskTxHash: 'RskTestTxId',
             rskSenderAddress: 'testSenderAddress',
@@ -199,8 +206,8 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.WAITING_FOR_CONFIRMATION,
-            btcRawTransaction: 'testBtcRawTx',
+            status: PegoutStatuses.WAITING_FOR_CONFIRMATION,
+            btcTxId: '86264805cc07e98eb7744f1584ac1aa0d584e2d2830f7d3da353a118c6ae8544',
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
     });
@@ -214,14 +221,14 @@ describe('Pegout Status Service:', () => {
                 valueRequestedInSatoshis: 500000,
                 valueInSatoshisToBeReceived: 495000,
                 feeInSatoshisToBePaid: 5000,
-                status: PegoutStatus.WAITING_FOR_SIGNATURE,
-                btcRawTransaction: 'testBtcRawTx',
+                status: PegoutStatuses.WAITING_FOR_SIGNATURE,
+                btcRawTransaction: testBtcRawTx,
                 originatingRskTxHash: 'RskTestTxId',
                 rskBlockHeight: 3158962,
                 lastUpdatedOn: Date.now(),
             });
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
-        const expectedResponse = new PegoutStatusAppDataModel({
+        const expectedResponse = new PegoutStatus({
             originatingRskTxHash: 'RskTestTxId',
             rskTxHash: 'RskTestTxId',
             rskSenderAddress: 'testSenderAddress',
@@ -229,8 +236,8 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.WAITING_FOR_SIGNATURE,
-            btcRawTransaction: 'testBtcRawTx',
+            status: PegoutStatuses.WAITING_FOR_SIGNATURE,
+            btcTxId: '86264805cc07e98eb7744f1584ac1aa0d584e2d2830f7d3da353a118c6ae8544',
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
     });
@@ -244,14 +251,14 @@ describe('Pegout Status Service:', () => {
                 valueRequestedInSatoshis: 500000,
                 valueInSatoshisToBeReceived: 495000,
                 feeInSatoshisToBePaid: 5000,
-                status: PegoutStatus.SIGNED,
-                btcRawTransaction: 'testBtcRawTx',
+                status: PegoutStatuses.SIGNED,
+                btcRawTransaction: testBtcRawTx,
                 originatingRskTxHash: 'RskTestTxId',
                 rskBlockHeight: 3158962,
                 lastUpdatedOn: Date.now(),
             });
         const pegoutStatus = await pegoutStatusService.getPegoutStatusByRskTxHash('RskTestTxId');
-        const expectedResponse = new PegoutStatusAppDataModel({
+        const expectedResponse = new PegoutStatus({
             originatingRskTxHash: 'RskTestTxId',
             rskTxHash: 'RskTestTxId',
             rskSenderAddress: 'testSenderAddress',
@@ -259,8 +266,8 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.SIGNED,
-            btcRawTransaction: 'testBtcRawTx',
+            status: PegoutStatuses.SIGNED,
+            btcTxId: '86264805cc07e98eb7744f1584ac1aa0d584e2d2830f7d3da353a118c6ae8544',
         });
         expect(pegoutStatus).to.be.deepEqual(expectedResponse);
     });
@@ -280,13 +287,30 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.SIGNED,
-            btcRawTransaction: 'testBtcRawTx',
+            status: PegoutStatuses.SIGNED,
+            btcRawTransaction: testBtcRawTx,
         });
 
         const pegoutStatus = await pegoutStatusService.sanitizePegout(expectedResponse);
         return expect(pegoutStatus.rskTxHash)
             .to.be.equal('123');
+    });
+
+    it('verify sanitize method when there are not rawTx', async () => {
+        const expectedResponse = new PegoutStatusAppDataModel({
+            originatingRskTxHash: 'RskTestTxId',
+            rskTxHash: '123___123',
+            rskSenderAddress: 'testSenderAddress',
+            btcRecipientAddress: 'testBtcRecipientAddress',
+            valueRequestedInSatoshis: 500000,
+            valueInSatoshisToBeReceived: 495000,
+            feeInSatoshisToBePaid: 5000,
+            status: PegoutStatuses.SIGNED,
+            btcRawTransaction: undefined,
+        });
+
+        const pegoutStatus = await pegoutStatusService.sanitizePegout(expectedResponse);
+        return expect(pegoutStatus.btcTxId).to.be.undefined();
     });
 
     it('verify sanitize method when rskTxHash has no _ ', async () => {
@@ -298,8 +322,8 @@ describe('Pegout Status Service:', () => {
             valueRequestedInSatoshis: 500000,
             valueInSatoshisToBeReceived: 495000,
             feeInSatoshisToBePaid: 5000,
-            status: PegoutStatus.SIGNED,
-            btcRawTransaction: 'testBtcRawTx',
+            status: PegoutStatuses.SIGNED,
+            btcRawTransaction: testBtcRawTx,
         });
 
         const pegoutStatus = await pegoutStatusService.sanitizePegout(expectedResponse);

--- a/src/__tests__/unit/services/rsk-node.services.unit.ts
+++ b/src/__tests__/unit/services/rsk-node.services.unit.ts
@@ -12,10 +12,6 @@ describe('Service: RskNodeService', () => {
         const block = await thisService.getBlock(getInitialBlock().height);
         sinon.assert.match(block.number, getInitialBlock().height);
     });
-    it('Verify ${process.env.RSK_NODE_HOST} configuration', async () => {
-        const nodeHost = process.env.RSK_NODE_HOST;
-        sinon.assert.match(nodeHost, 'https://public-node.testnet.rsk.co');
-    });
     it('Searches the Tx receipt', async () => {
         const simpleTransaction = "0x368cfbff365655d14eeaaba822c20fa8bb0c98fda0eef938094dee4ec7a83a66";
         const thisService = new RskNodeService();

--- a/src/controllers/tx-status.controller.ts
+++ b/src/controllers/tx-status.controller.ts
@@ -5,7 +5,7 @@ import {PeginStatus, Status, TxStatus, TxStatusType} from '../models';
 import {PeginStatusError} from "../models/pegin-status-error.model";
 import {ServicesBindings} from "../dependency-injection-bindings";
 import {PeginStatusService, PegoutStatusService, FlyoverService} from "../services";
-import {PegoutStatus} from "../models/rsk/pegout-status-data-model";
+import {PegoutStatuses} from "../models/rsk/pegout-status-data-model";
 import {ensure0x, remove0x} from '../utils/hex-utils';
 import {isValidTxId} from '../utils/tx-validator';
 import {TX_TYPE_PEGIN, TX_TYPE_PEGOUT} from '../constants';
@@ -71,7 +71,7 @@ export class TxStatusController {
       const txHash = ensure0x(txId);
       this.logger.debug(`[getTxStatus] trying to get a pegout with txHash: ${txHash}`);
       const pegoutStatus = await this.pegoutStatusService.getPegoutStatusByRskTxHash(txHash);
-      if (pegoutStatus.status !== PegoutStatus.NOT_FOUND) {
+      if (pegoutStatus.status !== PegoutStatuses.NOT_FOUND) {
         this.logger.debug(`[getTxStatus] Pegout status got for txId ${txHash} - Status: ${pegoutStatus.status}`);
         txStatus = new TxStatus({
           type: TxStatusType.PEGOUT,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -18,3 +18,4 @@ export *from './btc-last-block.model';
 export * from './fee-amount.model';
 export * from './register-payload.model';
 export * from './features.model';
+export * from './pegout-status.model';

--- a/src/models/pegout-status.model.ts
+++ b/src/models/pegout-status.model.ts
@@ -1,0 +1,70 @@
+import {Model, model, property} from '@loopback/repository';
+import { PegoutStatuses } from './rsk/pegout-status-data-model';
+
+@model()
+export class PegoutStatus extends Model {
+  @property({
+    type: 'string',
+    required: true,
+  })
+  originatingRskTxHash: string;
+
+  @property({
+    type: 'string',
+  })
+  rskTxHash?: string;
+
+  @property({
+    type: 'string',
+  })
+  rskSenderAddress?: string;
+
+  @property({
+    type: 'string',
+  })
+  btcRecipientAddress?: string;
+
+  @property({
+    type: 'number',
+    required: true,
+  })
+  valueRequestedInSatoshis: number;
+
+  @property({
+    type: 'number',
+  })
+  valueInSatoshisToBeReceived?: number;
+
+  @property({
+    type: 'number',
+  })
+  feeInSatoshisToBePaid?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  status: PegoutStatuses;
+
+  @property({
+    type: 'string',
+  })
+  btcTxId?: string;
+
+
+  constructor(data: Partial<PegoutStatus> = {}) {
+    super();
+    const sanitizedData: Partial<PegoutStatus> = {};
+    Object.entries(data).forEach(([key, value]) => {
+      const theKey = key as keyof PegoutStatus;
+      if (value !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        sanitizedData[theKey] = value;
+      }
+    });
+    Object.assign(this, sanitizedData);
+  }
+
+}
+

--- a/src/models/rsk/pegout-status-data-model.ts
+++ b/src/models/rsk/pegout-status-data-model.ts
@@ -1,7 +1,7 @@
 import ExtendedBridgeTx from '../../services/extended-bridge-tx';
 import { SearchableModel } from './searchable-model';
 
-export enum PegoutStatus {
+export enum PegoutStatuses {
   RECEIVED = 'RECEIVED',
   REJECTED = 'REJECTED',
   WAITING_FOR_CONFIRMATION = 'WAITING_FOR_CONFIRMATION',
@@ -21,7 +21,7 @@ export interface PegoutStatusDataModel {
   valueRequestedInSatoshis: number;
   valueInSatoshisToBeReceived: number;
   feeInSatoshisToBePaid: number;
-  status: PegoutStatus;
+  status: PegoutStatuses;
   btcRawTransaction: string;
 }
 
@@ -76,7 +76,7 @@ export class PegoutStatusAppDataModel implements PegoutStatusDataModel{
   valueRequestedInSatoshis: number;
   valueInSatoshisToBeReceived: number;
   feeInSatoshisToBePaid: number;
-  status: PegoutStatus;
+  status: PegoutStatuses;
   btcRawTransaction: string;
   originatingRskTxHash: string;
   createdOn: Date;
@@ -87,7 +87,7 @@ export class PegoutStatusDbDataModel implements SearchableModel, PegoutStatusDat
   rskBlockHash: string;
   rskBlockHeight: number;
   rskSenderAddress: string;
-  status: PegoutStatus;
+  status: PegoutStatuses;
   isNewestStatus: boolean;
   createdOn: Date;
   originatingRskTxHash: string; // First pegout rskTxHash, the one the user should have.

--- a/src/models/tx-status.model.ts
+++ b/src/models/tx-status.model.ts
@@ -1,13 +1,13 @@
 import {Model, model, property} from '@loopback/repository';
 import {PeginStatus} from "./pegin-status.model";
-import {PegoutStatusDataModel} from "./rsk/pegout-status-data-model";
+import { PegoutStatus } from './pegout-status.model';
 
 @model()
 export class TxStatus extends Model {
   @property({
     type: 'object',
   })
-  txDetails?: PeginStatus | PegoutStatusDataModel;
+  txDetails?: PeginStatus | PegoutStatus;
 
   @property({
     type: 'string',

--- a/src/services/pegout-data.processor.ts
+++ b/src/services/pegout-data.processor.ts
@@ -8,7 +8,7 @@ import FilteredBridgeTransactionProcessor from './filtered-bridge-transaction-pr
 import { BridgeDataFilterModel } from '../models/bridge-data-filter.model';
 import { PegoutStatusDataService } from './pegout-status-data-services/pegout-status-data.service';
 import ExtendedBridgeTx from './extended-bridge-tx';
-import { PegoutStatus, PegoutStatusDbDataModel } from '../models/rsk/pegout-status-data-model';
+import { PegoutStatuses, PegoutStatusDbDataModel } from '../models/rsk/pegout-status-data-model';
 import { ServicesBindings } from '../dependency-injection-bindings';
 import {BridgeService} from './bridge.service';
 import * as constants from '../constants';
@@ -154,7 +154,7 @@ export class PegoutDataProcessor implements FilteredBridgeTransactionProcessor {
       newPegoutStatus.btcRawTransaction = rawTx;
       newPegoutStatus.btcTxHash = parsedBtcTransaction.getHash().toString('hex');
       newPegoutStatus.isNewestStatus = true;
-      newPegoutStatus.status = PegoutStatus.RELEASE_BTC;
+      newPegoutStatus.status = PegoutStatuses.RELEASE_BTC;
       newPegoutStatus.valueInSatoshisToBeReceived = output.value;
       newPegoutStatus.feeInSatoshisToBePaid = newPegoutStatus.valueRequestedInSatoshis - newPegoutStatus.valueInSatoshisToBeReceived;
       newPegoutStatus.btcRawTxInputsHash = this.getInputsHash(parsedBtcTransaction);
@@ -205,7 +205,7 @@ export class PegoutDataProcessor implements FilteredBridgeTransactionProcessor {
 
       const newClonedPegoutStatus = PegoutStatusDbDataModel.clonePegoutStatusInstance(oldPegoutStatus);
       newClonedPegoutStatus.setRskTxInformation(extendedBridgeTx);
-      newClonedPegoutStatus.status = PegoutStatus.WAITING_FOR_CONFIRMATION;
+      newClonedPegoutStatus.status = PegoutStatuses.WAITING_FOR_CONFIRMATION;
       newClonedPegoutStatus.isNewestStatus = true;
       // Many pegouts with HOP will share the same rskTxHash, so, appending the index to differentiate them
       // and make each have a unique rskTxHash that includes to which btc tx output index each pegout belongs
@@ -284,7 +284,7 @@ export class PegoutDataProcessor implements FilteredBridgeTransactionProcessor {
       newStatus.setRskTxInformation(extendedBridgeTx);
       newStatus.rskTxHash = `${extendedBridgeTx.txHash}__${index}`;
       newStatus.isNewestStatus = true;
-      newStatus.status = PegoutStatus.WAITING_FOR_SIGNATURE;
+      newStatus.status = PegoutStatuses.WAITING_FOR_SIGNATURE;
       oldStatus.isNewestStatus = false;
       try {
         await this.saveMany([oldStatus, newStatus]);
@@ -321,7 +321,7 @@ export class PegoutDataProcessor implements FilteredBridgeTransactionProcessor {
     newPegoutStatus.setRskTxInformation(extendedBridgeTx);
     newPegoutStatus.originatingRskTxHash = originatingRskTxHash;
     newPegoutStatus.btcTxHash = btcTxHash;
-    newPegoutStatus.status = PegoutStatus.WAITING_FOR_CONFIRMATION;
+    newPegoutStatus.status = PegoutStatuses.WAITING_FOR_CONFIRMATION;
     newPegoutStatus.isNewestStatus = true;
 
     this.logPegoutData(newPegoutStatus);

--- a/src/services/pegout-status-data-services/pegout-status-mongo.service.ts
+++ b/src/services/pegout-status-data-services/pegout-status-mongo.service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import mongoose from 'mongoose';
-import {PegoutStatus, PegoutStatusDbDataModel} from '../../models/rsk/pegout-status-data-model';
+import {PegoutStatuses, PegoutStatusDbDataModel} from '../../models/rsk/pegout-status-data-model';
 import {MongoDbDataService} from '../mongodb-data.service';
 import {PegoutStatusDataService} from './pegout-status-data.service';
 
@@ -19,7 +19,7 @@ const PegoutStatusSchema = new mongoose.Schema({
   valueInSatoshisToBeReceived: {type: Number, required: true},
   feeInSatoshisToBePaid: {type: Number, required: true},
   btcRawTransaction: {type: String, required: true},
-  status: {type: String, required: true, enum: Object.values(PegoutStatus)},
+  status: {type: String, required: true, enum: Object.values(PegoutStatuses)},
   createdOn: {type: Date, required: true},
   rskBlockHeight: {type: Number, required: true},
   originatingRskBlockHeight: {type: Number, required: true},
@@ -101,35 +101,35 @@ export class PegoutStatusMongoDbDataService extends MongoDbDataService<PegoutSta
 
   public async getAllNotFinishedByBtcRecipientAddress(btcRecipientAddress: string): Promise<PegoutStatusDbDataModel[]> {
     const pegoutDocuments = await this.getConnector()
-    .find({status:  PegoutStatus.WAITING_FOR_CONFIRMATION, btcRecipientAddress})
+    .find({status:  PegoutStatuses.WAITING_FOR_CONFIRMATION, btcRecipientAddress})
     .exec();
     return pegoutDocuments.map(PegoutStatusDbDataModel.clonePegoutStatusInstance);
   }
 
   public async getPegoutByRecipientAndCreationTx(btcRecipientAddress: string, batchPegoutRskTxHash: string ): Promise<PegoutStatusDbDataModel[]> {
     const pegoutDocuments = await this.getConnector()
-      .find({status: { $ne: PegoutStatus.RELEASE_BTC },isNewestStatus: true, btcRecipientAddress, batchPegoutRskTxHash})
+      .find({status: { $ne: PegoutStatuses.RELEASE_BTC },isNewestStatus: true, btcRecipientAddress, batchPegoutRskTxHash})
       .exec();
     return pegoutDocuments.map(PegoutStatusDbDataModel.clonePegoutStatusInstance);
   }
 
   public async getManyWaitingForConfirmationNewest(): Promise<PegoutStatusDbDataModel[]> {
     const pegoutsDocuments = await this.getConnector()
-    .find({status: PegoutStatus.WAITING_FOR_CONFIRMATION, isNewestStatus: true})
+    .find({status: PegoutStatuses.WAITING_FOR_CONFIRMATION, isNewestStatus: true})
     .exec();
     return pegoutsDocuments.map(PegoutStatusDbDataModel.clonePegoutStatusInstance);
   }
 
   public async getManyWaitingForConfirmationNewestCreatedOnBlock(block: number): Promise<PegoutStatusDbDataModel[]> {
     const pegoutsDocuments = await this.getConnector()
-    .find({status: PegoutStatus.WAITING_FOR_CONFIRMATION, isNewestStatus: true, rskBlockHeight: block})
+    .find({status: PegoutStatuses.WAITING_FOR_CONFIRMATION, isNewestStatus: true, rskBlockHeight: block})
     .exec();
     return pegoutsDocuments.map(PegoutStatusDbDataModel.clonePegoutStatusInstance);
   }
 
   public async getManyWaitingForSignaturesNewest(): Promise<PegoutStatusDbDataModel[]> {
     const pegoutsDocuments = await  this.getConnector()
-    .find({status: PegoutStatus.WAITING_FOR_SIGNATURE, isNewestStatus: true})
+    .find({status: PegoutStatuses.WAITING_FOR_SIGNATURE, isNewestStatus: true})
     .exec();
     return pegoutsDocuments.map(PegoutStatusDbDataModel.clonePegoutStatusInstance);
   }

--- a/src/services/pegout-status/pegout-status-builder.ts
+++ b/src/services/pegout-status/pegout-status-builder.ts
@@ -1,5 +1,5 @@
 import ExtendedBridgeTx from '../extended-bridge-tx';
-import { PegoutStatus, PegoutStatusDbDataModel } from '../../models/rsk/pegout-status-data-model';
+import { PegoutStatuses, PegoutStatusDbDataModel } from '../../models/rsk/pegout-status-data-model';
 import { BRIDGE_EVENTS } from '../../utils/bridge-utils';
 import { BtcAddressUtils } from '../../utils/btc-utils';
 import {ExtendedBridgeEvent} from "../../models/types/bridge-transaction-parser";
@@ -24,7 +24,7 @@ export class PegoutStatusBuilder {
         status.btcRecipientAddress = btcDestinationAddress;
         status.valueRequestedInSatoshis = amount;
         status.originatingRskBlockHeight = extendedBridgeTx.blockNumber;
-        status.status = PegoutStatus.RECEIVED;
+        status.status = PegoutStatuses.RECEIVED;
         status.rskBlockHash = extendedBridgeTx.blockHash;
         status.originatingRskBlockHash = extendedBridgeTx.blockHash;
         status.isNewestStatus = true;
@@ -50,7 +50,7 @@ export class PegoutStatusBuilder {
         status.valueRequestedInSatoshis = amount;
         status.reason = reason;
         status.originatingRskBlockHeight = extendedBridgeTx.blockNumber;
-        status.status = PegoutStatus.REJECTED;
+        status.status = PegoutStatuses.REJECTED;
         status.isNewestStatus = true;
         return status;
     }

--- a/src/utils/btc-utils.ts
+++ b/src/utils/btc-utils.ts
@@ -148,4 +148,10 @@ export class BtcAddressUtils {
     }
     return { valid, addressType};
   }
+
+  public getBtcTxIdFromRawTransaction(rawTx: string): string {
+    const tx = bitcoin.Transaction.fromHex(rawTx);
+    return tx.getId();
+  }
+
 }


### PR DESCRIPTION
		I've updated the PegoutStatus model in order to handle separately
		the DB model and the requested value from the App. it no longer return
		the whole btc raw transaction, insted it returns only the txId