### PR TITLE
[SEC] fix:codeql-gha-permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,8 @@ on:
     branches: [ "main", "**-rc", "bugfix/**", "**-integration" ]
   schedule:
     - cron: "47 7 * * 5"
+permissions:
+  contents: read
 
 jobs:
   analyze:


### PR DESCRIPTION
Recommendation to fix:
https://github.com/rsksmart/2wp-api/security/code-scanning/54 